### PR TITLE
Add skills system with agentskills.io format support

### DIFF
--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -27,7 +27,7 @@ var agentCreateCmd = &cobra.Command{
 		ui.Header("Create a new agent")
 
 		var name, desc, model string
-		var contextRaw, instructions string
+		var contextRaw, skillsRaw, instructions string
 
 		basics := huh.NewForm(
 			huh.NewGroup(
@@ -65,6 +65,11 @@ var agentCreateCmd = &cobra.Command{
 
 			huh.NewGroup(
 				huh.NewText().
+					Title("Skills").
+					Description("skill names or URLs — one per line (optional, press enter to skip).\nuse 'toc skill list' to see available skills.").
+					Value(&skillsRaw),
+
+				huh.NewText().
 					Title("Context sync patterns").
 					Description("files matching these patterns sync back from sessions to the agent template.\none per line, e.g. context/*.md, docs/, notes.txt (optional, press enter to skip)").
 					Value(&contextRaw),
@@ -80,7 +85,7 @@ var agentCreateCmd = &cobra.Command{
 			return err
 		}
 
-		// Parse context patterns from multiline input
+		// Parse multiline inputs
 		var contextPatterns []string
 		if contextRaw != "" {
 			for _, line := range strings.Split(contextRaw, "\n") {
@@ -91,12 +96,23 @@ var agentCreateCmd = &cobra.Command{
 			}
 		}
 
+		var skills []string
+		if skillsRaw != "" {
+			for _, line := range strings.Split(skillsRaw, "\n") {
+				line = strings.TrimSpace(line)
+				if line != "" {
+					skills = append(skills, line)
+				}
+			}
+		}
+
 		cfg := agent.AgentConfig{
 			Runtime:     "claude-code",
 			Name:        name,
 			Description: desc,
 			Model:       model,
 			Context:     contextPatterns,
+			Skills:      skills,
 		}
 
 		agentMD := ""
@@ -117,6 +133,9 @@ var agentCreateCmd = &cobra.Command{
 		fmt.Println()
 		ui.Success("Created agent %s", ui.Bold(name))
 		ui.Info("Config: %s", ui.Dim(agent.Dir(name)+"/oc-agent.yaml"))
+		if len(skills) > 0 {
+			ui.Info("Skills: %s", ui.Dim(fmt.Sprintf("%d skill(s)", len(skills))))
+		}
 		if len(contextPatterns) > 0 {
 			ui.Info("Context sync: %s", ui.Dim(fmt.Sprintf("%d pattern(s)", len(contextPatterns))))
 		}

--- a/cmd/agent_skills.go
+++ b/cmd/agent_skills.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/agent"
+	"github.com/tiny-oc/toc/internal/audit"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/skill"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	agentCmd.AddCommand(agentSkillsCmd)
+}
+
+var agentSkillsCmd = &cobra.Command{
+	Use:               "skills <agent-name>",
+	Short:             "Manage skills for an agent",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeAgentNames,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		name := args[0]
+		cfg, err := agent.Load(name)
+		if err != nil {
+			return err
+		}
+
+		// Build list of available skills (local + url refs)
+		locals, _ := skill.ListLocal()
+		reg, _ := skill.LoadRegistry()
+
+		// Build a set of currently enabled skills for pre-selection
+		enabled := make(map[string]bool)
+		for _, s := range cfg.Skills {
+			enabled[s] = true
+		}
+
+		var options []huh.Option[string]
+		for _, s := range locals {
+			label := fmt.Sprintf("%s — %s (local)", s.Name, truncate(s.Description, 50))
+			options = append(options, huh.NewOption(label, s.Name))
+		}
+		for _, r := range reg.Skills {
+			label := fmt.Sprintf("%s — %s (url)", r.Name, r.URL)
+			options = append(options, huh.NewOption(label, r.Name))
+		}
+
+		if len(options) == 0 {
+			ui.Warn("No skills available. Run %s or %s first.", ui.Bold("toc skill create"), ui.Bold("toc skill add <url>"))
+			return nil
+		}
+
+		// Pre-populate with currently enabled skills so huh pre-selects them
+		selected := make([]string, len(cfg.Skills))
+		copy(selected, cfg.Skills)
+
+		ui.Header(fmt.Sprintf("Skills for %s", ui.Bold(name)))
+
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewMultiSelect[string]().
+					Title("Select skills to enable").
+					Value(&selected).
+					Height(len(options)+3).
+					Options(options...),
+			),
+		)
+
+		if err := form.Run(); err != nil {
+			return err
+		}
+
+		cfg.Skills = selected
+		if err := agent.Save(cfg); err != nil {
+			return err
+		}
+
+		_ = audit.Log("agent.skills.update", map[string]interface{}{
+			"agent":  name,
+			"skills": strings.Join(selected, ", "),
+		})
+
+		fmt.Println()
+		if len(selected) == 0 {
+			ui.Success("Cleared all skills for %s", ui.Bold(name))
+		} else {
+			ui.Success("Updated skills for %s: %s", ui.Bold(name), ui.Dim(strings.Join(selected, ", ")))
+		}
+		fmt.Println()
+		return nil
+	},
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func init() {
+	rootCmd.AddCommand(skillCmd)
+}
+
+var skillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage skills",
+}

--- a/cmd/skill_add.go
+++ b/cmd/skill_add.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/audit"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/skill"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	skillCmd.AddCommand(skillAddCmd)
+}
+
+var skillAddCmd = &cobra.Command{
+	Use:   "add <url>",
+	Short: "Add a skill from a public Git repository",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		url := args[0]
+		if !skill.IsURL(url) {
+			return fmt.Errorf("expected a URL (https://...), got: %s", url)
+		}
+
+		ui.Info("Validating skill at %s...", ui.Dim(url))
+
+		// Clone to temp for validation
+		tmpDir, err := os.MkdirTemp("", "toc-skill-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp directory: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		gitCmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
+		gitCmd.Stdout = io.Discard
+		gitCmd.Stderr = io.Discard
+		if err := gitCmd.Run(); err != nil {
+			return fmt.Errorf("failed to clone repository — is the URL correct and public?")
+		}
+
+		// Find and validate SKILL.md
+		skillDir, err := skill.FindSkillMDInDir(tmpDir)
+		if err != nil {
+			return err
+		}
+
+		meta, err := skill.ValidateSkillDir(skillDir)
+		if err != nil {
+			return err
+		}
+
+		// Check for conflicts
+		if skill.Exists(meta.Name) {
+			return fmt.Errorf("a local skill named '%s' already exists — remove it first or use a different name", meta.Name)
+		}
+
+		// Store reference
+		if err := skill.AddRef(skill.SkillRef{Name: meta.Name, URL: url}); err != nil {
+			return err
+		}
+
+		_ = audit.Log("skill.add", map[string]interface{}{
+			"skill": meta.Name,
+			"url":   url,
+		})
+
+		fmt.Println()
+		ui.Success("Added skill %s from %s", ui.Bold(meta.Name), ui.Dim(url))
+		ui.Info("This skill will be resolved fresh from the URL each time an agent session is spawned.")
+		fmt.Println()
+		return nil
+	},
+}

--- a/cmd/skill_create.go
+++ b/cmd/skill_create.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/audit"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/skill"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	skillCmd.AddCommand(skillCreateCmd)
+}
+
+var skillCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new local skill interactively",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		ui.Header("Create a new skill")
+
+		var name, description string
+		var instructions string
+
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Skill name").
+					Description("lowercase letters, numbers, and hyphens (e.g. 'code-review')").
+					Value(&name).
+					Validate(func(s string) error {
+						if s == "" {
+							return fmt.Errorf("name is required")
+						}
+						if err := skill.ValidateName(s); err != nil {
+							return err
+						}
+						if skill.Exists(s) {
+							return fmt.Errorf("skill '%s' already exists", s)
+						}
+						return nil
+					}),
+
+				huh.NewInput().
+					Title("Description").
+					Description("what does this skill do and when should it be used?").
+					Value(&description).
+					Validate(func(s string) error {
+						if s == "" {
+							return fmt.Errorf("description is required")
+						}
+						if len(s) > 1024 {
+							return fmt.Errorf("description must be under 1024 characters")
+						}
+						return nil
+					}),
+			),
+
+			huh.NewGroup(
+				huh.NewText().
+					Title("Instructions").
+					Description("the skill's instructions — loaded when the skill is activated.\nyou can always edit SKILL.md later (optional, press enter to skip)").
+					Value(&instructions),
+			),
+		)
+
+		if err := form.Run(); err != nil {
+			return err
+		}
+
+		meta := skill.SkillMeta{
+			Name:        name,
+			Description: description,
+		}
+
+		body := ""
+		if strings.TrimSpace(instructions) != "" {
+			body = strings.TrimSpace(instructions)
+		}
+
+		if err := skill.CreateFromMeta(meta, body); err != nil {
+			return err
+		}
+
+		_ = audit.Log("skill.create", map[string]interface{}{
+			"skill": name,
+		})
+
+		fmt.Println()
+		ui.Success("Created skill %s", ui.Bold(name))
+		ui.Info("SKILL.md: %s", ui.Dim(skill.Dir(name)+"/SKILL.md"))
+		if body == "" {
+			ui.Info("Edit %s to add instructions.", ui.Bold(skill.Dir(name)+"/SKILL.md"))
+		}
+		fmt.Println()
+		return nil
+	},
+}

--- a/cmd/skill_list.go
+++ b/cmd/skill_list.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/skill"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	skillCmd.AddCommand(skillListCmd)
+}
+
+var skillListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all skills",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		locals, err := skill.ListLocal()
+		if err != nil {
+			return err
+		}
+
+		reg, err := skill.LoadRegistry()
+		if err != nil {
+			return err
+		}
+
+		if len(locals) == 0 && len(reg.Skills) == 0 {
+			ui.Warn("No skills configured. Run %s or %s to add one.", ui.Bold("toc skill create <name>"), ui.Bold("toc skill add <url>"))
+			return nil
+		}
+
+		fmt.Println()
+		fmt.Printf("  %-20s %-8s %s\n", ui.Bold("NAME"), ui.Bold("TYPE"), ui.Bold("DESCRIPTION"))
+		fmt.Printf("  %-20s %-8s %s\n", ui.Dim("────────────────────"), ui.Dim("────────"), ui.Dim("───────────────────────────────"))
+
+		for _, s := range locals {
+			desc := s.Description
+			if len(desc) > 50 {
+				desc = desc[:47] + "..."
+			}
+			fmt.Printf("  %-20s %-8s %s\n", ui.Cyan(s.Name), "local", ui.Dim(desc))
+		}
+
+		for _, r := range reg.Skills {
+			fmt.Printf("  %-20s %-8s %s\n", ui.Cyan(r.Name), "url", ui.Dim(r.URL))
+		}
+
+		fmt.Println()
+		return nil
+	},
+}

--- a/cmd/skill_remove.go
+++ b/cmd/skill_remove.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/audit"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/skill"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	skillCmd.AddCommand(skillRemoveCmd)
+}
+
+var skillRemoveCmd = &cobra.Command{
+	Use:               "remove <name>",
+	Short:             "Remove a skill",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeSkillNames,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		name := args[0]
+
+		// Determine if it's a local skill or URL reference
+		isLocal := skill.Exists(name)
+		_, refErr := skill.FindRef(name)
+		isRef := refErr == nil
+
+		if !isLocal && !isRef {
+			return fmt.Errorf("skill '%s' not found", name)
+		}
+
+		skillType := "local"
+		if !isLocal && isRef {
+			skillType = "url"
+		}
+
+		confirm, err := ui.Prompt(fmt.Sprintf("Remove %s skill %s? (y/N)", skillType, ui.Bold(name)), "n")
+		if err != nil {
+			return err
+		}
+		if confirm != "y" && confirm != "Y" {
+			ui.Info("Cancelled.")
+			return nil
+		}
+
+		if isLocal {
+			if err := skill.Remove(name); err != nil {
+				return err
+			}
+		}
+		if isRef {
+			if err := skill.RemoveRef(name); err != nil {
+				return err
+			}
+		}
+
+		_ = audit.Log("skill.remove", map[string]interface{}{
+			"skill": name,
+			"type":  skillType,
+		})
+
+		fmt.Println()
+		ui.Success("Removed skill %s", ui.Bold(name))
+		fmt.Println()
+		return nil
+	},
+}
+
+func completeSkillNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 || !config.Exists() {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+
+	locals, _ := skill.ListLocal()
+	for _, s := range locals {
+		completions = append(completions, fmt.Sprintf("%s\t%s (local)", s.Name, s.Description))
+	}
+
+	reg, _ := skill.LoadRegistry()
+	for _, r := range reg.Skills {
+		completions = append(completions, fmt.Sprintf("%s\t%s (url)", r.Name, r.URL))
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tiny-oc/toc/internal/agent"
 	"github.com/tiny-oc/toc/internal/config"
 	"github.com/tiny-oc/toc/internal/session"
+	"github.com/tiny-oc/toc/internal/skill"
 	"github.com/tiny-oc/toc/internal/ui"
 )
 
@@ -58,6 +59,31 @@ var statusCmd = &cobra.Command{
 				} else {
 					fmt.Printf("    %s %s %s\n", ui.Red("✗"), ui.Cyan(a.Name), ui.Red(strings.Join(problems, ", ")))
 				}
+				if len(a.Skills) > 0 {
+					fmt.Printf("      %s %s\n", ui.Dim("skills:"), ui.Dim(strings.Join(a.Skills, ", ")))
+				}
+			}
+		}
+		fmt.Println()
+
+		// Skills
+		locals, _ := skill.ListLocal()
+		reg, _ := skill.LoadRegistry()
+		totalSkills := len(locals) + len(reg.Skills)
+		fmt.Printf("  %s", ui.Bold("Skills"))
+		if totalSkills == 0 {
+			fmt.Printf("  %s\n", ui.Dim("none"))
+		} else {
+			fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d)", totalSkills)))
+			for _, s := range locals {
+				desc := s.Description
+				if len(desc) > 50 {
+					desc = desc[:47] + "..."
+				}
+				fmt.Printf("    %s %s %s\n", ui.Dim("▪"), ui.Cyan(s.Name), ui.Dim(desc))
+			}
+			for _, r := range reg.Skills {
+				fmt.Printf("    %s %s %s\n", ui.Dim("▪"), ui.Cyan(r.Name), ui.Dim(r.URL))
 			}
 		}
 		fmt.Println()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,6 +18,7 @@ type AgentConfig struct {
 	Description string   `yaml:"description,omitempty"`
 	Model       string   `yaml:"model"`
 	Context     []string `yaml:"context,omitempty"`
+	Skills      []string `yaml:"skills,omitempty"`
 }
 
 func ValidateName(name string) error {
@@ -70,6 +71,14 @@ func Load(name string) (*AgentConfig, error) {
 		return nil, fmt.Errorf("failed to parse agent config: %w", err)
 	}
 	return &cfg, nil
+}
+
+func Save(cfg *AgentConfig) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal agent config: %w", err)
+	}
+	return os.WriteFile(filepath.Join(Dir(cfg.Name), "oc-agent.yaml"), data, 0644)
 }
 
 func Create(cfg AgentConfig) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,14 @@ func AgentsDir() string {
 	return filepath.Join(tocDir, "agents")
 }
 
+func SkillsDir() string {
+	return filepath.Join(tocDir, "skills")
+}
+
+func SkillsRegistryPath() string {
+	return filepath.Join(tocDir, "skills.yaml")
+}
+
 func SessionsPath() string {
 	return filepath.Join(tocDir, "sessions.yaml")
 }
@@ -73,6 +81,9 @@ func Init(name string) error {
 	}
 	if err := os.MkdirAll(AgentsDir(), 0755); err != nil {
 		return fmt.Errorf("failed to create agents directory: %w", err)
+	}
+	if err := os.MkdirAll(SkillsDir(), 0755); err != nil {
+		return fmt.Errorf("failed to create skills directory: %w", err)
 	}
 	return Save(&WorkspaceConfig{Name: name})
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,313 @@
+package skill
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/tiny-oc/toc/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// SkillMeta represents the YAML frontmatter parsed from SKILL.md.
+type SkillMeta struct {
+	Name          string            `yaml:"name"`
+	Description   string            `yaml:"description"`
+	License       string            `yaml:"license,omitempty"`
+	Compatibility string            `yaml:"compatibility,omitempty"`
+	Metadata      map[string]string `yaml:"metadata,omitempty"`
+	AllowedTools  string            `yaml:"allowed-tools,omitempty"`
+}
+
+// SkillRef represents a URL-based skill reference stored in .toc/skills.yaml.
+type SkillRef struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}
+
+// SkillsRegistry is the top-level structure for .toc/skills.yaml.
+type SkillsRegistry struct {
+	Skills []SkillRef `yaml:"skills"`
+}
+
+func ValidateName(name string) error {
+	if !validName.MatchString(name) {
+		return fmt.Errorf("skill name must be lowercase alphanumeric with hyphens (e.g. 'code-review')")
+	}
+	if strings.HasSuffix(name, "-") {
+		return fmt.Errorf("skill name must not end with a hyphen")
+	}
+	if strings.Contains(name, "--") {
+		return fmt.Errorf("skill name must not contain consecutive hyphens")
+	}
+	return nil
+}
+
+func Dir(name string) string {
+	return filepath.Join(config.SkillsDir(), name)
+}
+
+func Exists(name string) bool {
+	_, err := os.Stat(Dir(name))
+	return err == nil
+}
+
+// IsURL returns true if the entry looks like a URL skill reference.
+func IsURL(entry string) bool {
+	return strings.HasPrefix(entry, "https://") || strings.HasPrefix(entry, "http://")
+}
+
+// ParseSkillMD reads a SKILL.md file and extracts the YAML frontmatter.
+func ParseSkillMD(path string) (*SkillMeta, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var inFrontmatter bool
+	var frontmatterLines []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !inFrontmatter {
+			if strings.TrimSpace(line) == "---" {
+				inFrontmatter = true
+				continue
+			}
+			// Skip any content before first ---
+			continue
+		}
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		frontmatterLines = append(frontmatterLines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read SKILL.md: %w", err)
+	}
+
+	if len(frontmatterLines) == 0 {
+		return nil, fmt.Errorf("no YAML frontmatter found in SKILL.md")
+	}
+
+	var meta SkillMeta
+	if err := yaml.Unmarshal([]byte(strings.Join(frontmatterLines, "\n")), &meta); err != nil {
+		return nil, fmt.Errorf("failed to parse SKILL.md frontmatter: %w", err)
+	}
+
+	return &meta, nil
+}
+
+// ValidateSkillDir checks that a directory contains a valid SKILL.md.
+func ValidateSkillDir(dir string) (*SkillMeta, error) {
+	skillMD := filepath.Join(dir, "SKILL.md")
+	if _, err := os.Stat(skillMD); os.IsNotExist(err) {
+		return nil, fmt.Errorf("SKILL.md not found in %s", dir)
+	}
+
+	meta, err := ParseSkillMD(skillMD)
+	if err != nil {
+		return nil, err
+	}
+
+	if meta.Name == "" {
+		return nil, fmt.Errorf("SKILL.md missing required 'name' field")
+	}
+	if meta.Description == "" {
+		return nil, fmt.Errorf("SKILL.md missing required 'description' field")
+	}
+	if err := ValidateName(meta.Name); err != nil {
+		return nil, fmt.Errorf("invalid skill name in SKILL.md: %w", err)
+	}
+
+	return meta, nil
+}
+
+// FindSkillMDInDir looks for a SKILL.md at the root of dir, then one level deep.
+// Returns the directory containing the SKILL.md.
+func FindSkillMDInDir(dir string) (string, error) {
+	// Check root
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+		return dir, nil
+	}
+
+	// Check one level deep
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(dir, entry.Name())
+		if _, err := os.Stat(filepath.Join(candidate, "SKILL.md")); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("no SKILL.md found in repository")
+}
+
+// CreateFromMeta scaffolds a new local skill in .toc/skills/<name>/ with full metadata.
+func CreateFromMeta(meta SkillMeta, instructions string) error {
+	if err := ValidateName(meta.Name); err != nil {
+		return err
+	}
+	if Exists(meta.Name) {
+		return fmt.Errorf("skill '%s' already exists", meta.Name)
+	}
+
+	dir := Dir(meta.Name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create skill directory: %w", err)
+	}
+
+	content := renderSkillMD(meta, instructions)
+	return os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644)
+}
+
+func renderSkillMD(meta SkillMeta, instructions string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(fmt.Sprintf("name: %s\n", meta.Name))
+	b.WriteString(fmt.Sprintf("description: %s\n", meta.Description))
+	if meta.License != "" {
+		b.WriteString(fmt.Sprintf("license: %s\n", meta.License))
+	}
+	if meta.Compatibility != "" {
+		b.WriteString(fmt.Sprintf("compatibility: %s\n", meta.Compatibility))
+	}
+	if len(meta.Metadata) > 0 {
+		b.WriteString("metadata:\n")
+		for k, v := range meta.Metadata {
+			b.WriteString(fmt.Sprintf("  %s: %q\n", k, v))
+		}
+	}
+	b.WriteString("---\n\n")
+
+	if instructions != "" {
+		b.WriteString(instructions)
+		b.WriteString("\n")
+	} else {
+		b.WriteString(fmt.Sprintf("# %s\n\nAdd skill instructions here. These are loaded when the skill is activated.\n", meta.Name))
+	}
+
+	return b.String()
+}
+
+// Remove deletes a local skill directory.
+func Remove(name string) error {
+	dir := Dir(name)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("skill '%s' not found", name)
+	}
+	return os.RemoveAll(dir)
+}
+
+// ListLocal returns metadata for all local skills in .toc/skills/.
+func ListLocal() ([]SkillMeta, error) {
+	entries, err := os.ReadDir(config.SkillsDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var skills []SkillMeta
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		meta, err := ValidateSkillDir(filepath.Join(config.SkillsDir(), entry.Name()))
+		if err != nil {
+			continue // skip invalid skills
+		}
+		skills = append(skills, *meta)
+	}
+	return skills, nil
+}
+
+// LoadRegistry reads the URL skill references from .toc/skills.yaml.
+func LoadRegistry() (*SkillsRegistry, error) {
+	data, err := os.ReadFile(config.SkillsRegistryPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &SkillsRegistry{}, nil
+		}
+		return nil, err
+	}
+	var reg SkillsRegistry
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("failed to parse skills registry: %w", err)
+	}
+	return &reg, nil
+}
+
+// SaveRegistry writes the URL skill references to .toc/skills.yaml.
+func SaveRegistry(reg *SkillsRegistry) error {
+	data, err := yaml.Marshal(reg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(config.SkillsRegistryPath(), data, 0644)
+}
+
+// AddRef adds a URL skill reference to the registry.
+func AddRef(ref SkillRef) error {
+	reg, err := LoadRegistry()
+	if err != nil {
+		return err
+	}
+	for _, existing := range reg.Skills {
+		if existing.Name == ref.Name {
+			return fmt.Errorf("skill '%s' already registered", ref.Name)
+		}
+	}
+	reg.Skills = append(reg.Skills, ref)
+	return SaveRegistry(reg)
+}
+
+// RemoveRef removes a URL skill reference from the registry.
+func RemoveRef(name string) error {
+	reg, err := LoadRegistry()
+	if err != nil {
+		return err
+	}
+	var filtered []SkillRef
+	found := false
+	for _, r := range reg.Skills {
+		if r.Name == name {
+			found = true
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	if !found {
+		return fmt.Errorf("skill '%s' not found in registry", name)
+	}
+	reg.Skills = filtered
+	return SaveRegistry(reg)
+}
+
+// FindRef looks up a URL skill reference by name.
+func FindRef(name string) (*SkillRef, error) {
+	reg, err := LoadRegistry()
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range reg.Skills {
+		if r.Name == name {
+			return &r, nil
+		}
+	}
+	return nil, fmt.Errorf("skill '%s' not found in registry", name)
+}

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/tiny-oc/toc/internal/agent"
 	"github.com/tiny-oc/toc/internal/session"
+	"github.com/tiny-oc/toc/internal/skill"
 	tocsync "github.com/tiny-oc/toc/internal/sync"
 	"github.com/tiny-oc/toc/internal/ui"
 )
@@ -19,8 +20,9 @@ const sessionsDir = "/tmp/toc-sessions"
 
 // SpawnResult contains metadata from a completed spawn for audit logging.
 type SpawnResult struct {
-	SessionID   string
-	SyncedFiles int
+	SessionID    string
+	SyncedFiles  int
+	FailedSkills []string
 }
 
 func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
@@ -39,6 +41,17 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 
 	if err := copyDir(srcDir, workDir); err != nil {
 		return nil, fmt.Errorf("failed to copy agent template: %w", err)
+	}
+
+	// Convert agent.md into CLAUDE.md so Claude Code picks it up as instructions
+	if err := provisionClaudeMD(workDir); err != nil {
+		return nil, fmt.Errorf("failed to provision CLAUDE.md: %w", err)
+	}
+
+	// Resolve skills into session .claude/skills/
+	var failedSkills []string
+	if len(cfg.Skills) > 0 {
+		failedSkills = resolveSkills(workDir, cfg.Skills)
 	}
 
 	if len(cfg.Context) > 0 {
@@ -61,6 +74,10 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 	ui.Info("Model: %s", ui.Bold(cfg.Model))
 	ui.Info("Session: %s", ui.Cyan(sessionID))
 	ui.Info("Workspace: %s", ui.Dim(workDir))
+	if len(cfg.Skills) > 0 {
+		resolved := len(cfg.Skills) - len(failedSkills)
+		ui.Info("Skills: %s", ui.Dim(fmt.Sprintf("%d/%d resolved", resolved, len(cfg.Skills))))
+	}
 	if len(cfg.Context) > 0 {
 		ui.Info("Context sync: %s", ui.Dim(fmt.Sprintf("%d pattern(s)", len(cfg.Context))))
 	}
@@ -74,9 +91,10 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 		syncedFiles = runPostSessionSync(workDir, srcDir, cfg.Context)
 	}
 
+	printFailedSkills(failedSkills)
 	printResumeCommand(cfg.Name, sessionID)
 
-	return &SpawnResult{SessionID: sessionID, SyncedFiles: syncedFiles}, nil
+	return &SpawnResult{SessionID: sessionID, SyncedFiles: syncedFiles, FailedSkills: failedSkills}, nil
 }
 
 func ResumeSession(s *session.Session) (*SpawnResult, error) {
@@ -94,6 +112,12 @@ func ResumeSession(s *session.Session) (*SpawnResult, error) {
 		return nil, fmt.Errorf("failed to resolve agent directory: %w", err)
 	}
 
+	// Re-resolve skills in case they were cleaned up or updated
+	var failedSkills []string
+	if len(cfg.Skills) > 0 {
+		failedSkills = resolveSkills(s.WorkspacePath, cfg.Skills)
+	}
+
 	// Re-setup hooks in case they were cleaned up
 	if len(cfg.Context) > 0 {
 		if err := setupContextHooks(s.WorkspacePath, srcDir, cfg.Context); err != nil {
@@ -105,6 +129,10 @@ func ResumeSession(s *session.Session) (*SpawnResult, error) {
 	ui.Info("Resuming agent: %s", ui.Bold(s.Agent))
 	ui.Info("Session: %s", ui.Cyan(s.ID))
 	ui.Info("Workspace: %s", ui.Dim(s.WorkspacePath))
+	if len(cfg.Skills) > 0 {
+		resolved := len(cfg.Skills) - len(failedSkills)
+		ui.Info("Skills: %s", ui.Dim(fmt.Sprintf("%d/%d resolved", resolved, len(cfg.Skills))))
+	}
 	fmt.Println()
 
 	_ = launchClaude(s.WorkspacePath, cfg.Model, s.ID, true)
@@ -114,9 +142,10 @@ func ResumeSession(s *session.Session) (*SpawnResult, error) {
 		syncedFiles = runPostSessionSync(s.WorkspacePath, srcDir, cfg.Context)
 	}
 
+	printFailedSkills(failedSkills)
 	printResumeCommand(s.Agent, s.ID)
 
-	return &SpawnResult{SessionID: s.ID, SyncedFiles: syncedFiles}, nil
+	return &SpawnResult{SessionID: s.ID, SyncedFiles: syncedFiles, FailedSkills: failedSkills}, nil
 }
 
 func setupContextHooks(workDir, agentDir string, patterns []string) error {
@@ -188,6 +217,109 @@ func launchClaude(dir, model, sessionID string, resume bool) error {
 		return fmt.Errorf("failed to launch claude: %w", err)
 	}
 	return nil
+}
+
+// resolveSkills resolves all skill references and copies them into the session's
+// .claude/skills/ directory. Returns a list of skill entries that failed to resolve.
+func resolveSkills(workDir string, skills []string) []string {
+	skillsTarget := filepath.Join(workDir, ".claude", "skills")
+	if err := os.MkdirAll(skillsTarget, 0755); err != nil {
+		ui.Warn("Failed to create skills directory: %s", err)
+		return skills
+	}
+
+	var failed []string
+	for _, entry := range skills {
+		if skill.IsURL(entry) {
+			if err := resolveURLSkill(entry, skillsTarget); err != nil {
+				ui.Warn("Skill '%s': %s", entry, err)
+				failed = append(failed, entry)
+			}
+		} else {
+			if err := resolveNamedSkill(entry, skillsTarget); err != nil {
+				ui.Warn("Skill '%s': %s", entry, err)
+				failed = append(failed, entry)
+			}
+		}
+	}
+	return failed
+}
+
+// resolveNamedSkill resolves a skill by name: first checks local .toc/skills/<name>/,
+// then falls back to URL registry.
+func resolveNamedSkill(name string, targetDir string) error {
+	// Try local skill first
+	srcDir := skill.Dir(name)
+	if _, err := os.Stat(srcDir); err == nil {
+		return copyDir(srcDir, filepath.Join(targetDir, name))
+	}
+
+	// Fall back to URL registry
+	ref, err := skill.FindRef(name)
+	if err != nil {
+		return fmt.Errorf("not found as local skill or URL reference")
+	}
+
+	return cloneSkillToTarget(ref.URL, targetDir)
+}
+
+// resolveURLSkill resolves a skill directly from a URL.
+func resolveURLSkill(url string, targetDir string) error {
+	return cloneSkillToTarget(url, targetDir)
+}
+
+// cloneSkillToTarget clones a git repo, finds the SKILL.md, and copies the skill
+// directory into the target.
+func cloneSkillToTarget(url string, targetDir string) error {
+	tmpDir, err := os.MkdirTemp("", "toc-skill-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	gitCmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
+	gitCmd.Stdout = io.Discard
+	gitCmd.Stderr = io.Discard
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to clone %s", url)
+	}
+
+	skillDir, err := skill.FindSkillMDInDir(tmpDir)
+	if err != nil {
+		return err
+	}
+
+	meta, err := skill.ValidateSkillDir(skillDir)
+	if err != nil {
+		return err
+	}
+
+	return copyDir(skillDir, filepath.Join(targetDir, meta.Name))
+}
+
+func printFailedSkills(failed []string) {
+	if len(failed) == 0 {
+		return
+	}
+	fmt.Println()
+	ui.Warn("Some skills failed to resolve:")
+	for _, s := range failed {
+		fmt.Printf("  %s %s\n", ui.Red("✗"), s)
+	}
+	ui.Info("Consider removing or updating these skill references.")
+}
+
+// provisionClaudeMD renames agent.md to CLAUDE.md in the session workspace
+// so that Claude Code loads it as its project instructions.
+func provisionClaudeMD(workDir string) error {
+	agentMD := filepath.Join(workDir, "agent.md")
+	claudeMD := filepath.Join(workDir, "CLAUDE.md")
+
+	if _, err := os.Stat(agentMD); os.IsNotExist(err) {
+		return nil // no agent.md, nothing to do
+	}
+
+	return os.Rename(agentMD, claudeMD)
 }
 
 func copyDir(src, dst string) error {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -119,11 +119,17 @@ func SyncBack(sessionDir, agentDir string, patterns []string) (int, error) {
 			return err
 		}
 
-		if !MatchesAny(rel, patterns) {
+		// Map CLAUDE.md back to agent.md in the template
+		dstRel := rel
+		if rel == "CLAUDE.md" {
+			dstRel = "agent.md"
+		}
+
+		if !MatchesAny(dstRel, patterns) {
 			return nil
 		}
 
-		dst := filepath.Join(agentDir, rel)
+		dst := filepath.Join(agentDir, dstRel)
 		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 			return err
 		}
@@ -148,11 +154,17 @@ func SyncFile(filePath, sessionDir, agentDir string, patterns []string) (bool, e
 		return false, nil
 	}
 
-	if !MatchesAny(rel, patterns) {
+	// Map CLAUDE.md back to agent.md in the template
+	dstRel := rel
+	if rel == "CLAUDE.md" {
+		dstRel = "agent.md"
+	}
+
+	if !MatchesAny(dstRel, patterns) {
 		return false, nil
 	}
 
-	dst := filepath.Join(agentDir, rel)
+	dst := filepath.Join(agentDir, dstRel)
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return false, err
 	}
@@ -219,6 +231,12 @@ if [ "$REL_PATH" = "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Map CLAUDE.md back to agent.md for the agent template
+DST_REL="$REL_PATH"
+if [ "$REL_PATH" = "CLAUDE.md" ]; then
+  DST_REL="agent.md"
+fi
+
 # Check against each pattern and sync if matched
 AGENT_DIR="%s"
 PATTERNS=(%s)
@@ -227,31 +245,31 @@ for PATTERN in "${PATTERNS[@]}"; do
   # Directory pattern
   DIR_PATTERN="${PATTERN%%/}"
   if [ "$DIR_PATTERN" != "$PATTERN" ] || [ -d "%s/$DIR_PATTERN" ] 2>/dev/null; then
-    if [[ "$REL_PATH" == "$DIR_PATTERN"/* ]] || [ "$REL_PATH" = "$DIR_PATTERN" ]; then
-      mkdir -p "$(dirname "$AGENT_DIR/$REL_PATH")"
-      cp "$FILE_PATH" "$AGENT_DIR/$REL_PATH"
+    if [[ "$DST_REL" == "$DIR_PATTERN"/* ]] || [ "$DST_REL" = "$DIR_PATTERN" ]; then
+      mkdir -p "$(dirname "$AGENT_DIR/$DST_REL")"
+      cp "$FILE_PATH" "$AGENT_DIR/$DST_REL"
       exit 0
     fi
   fi
 
   # Glob pattern — use bash built-in matching
   # shellcheck disable=SC2254
-  case "$REL_PATH" in
+  case "$DST_REL" in
     $PATTERN)
-      mkdir -p "$(dirname "$AGENT_DIR/$REL_PATH")"
-      cp "$FILE_PATH" "$AGENT_DIR/$REL_PATH"
+      mkdir -p "$(dirname "$AGENT_DIR/$DST_REL")"
+      cp "$FILE_PATH" "$AGENT_DIR/$DST_REL"
       exit 0
       ;;
   esac
 
   # Also match just the filename for non-path patterns
-  BASENAME=$(basename "$REL_PATH")
+  BASENAME=$(basename "$DST_REL")
   if [[ "$PATTERN" != */* ]]; then
     # shellcheck disable=SC2254
     case "$BASENAME" in
       $PATTERN)
-        mkdir -p "$(dirname "$AGENT_DIR/$REL_PATH")"
-        cp "$FILE_PATH" "$AGENT_DIR/$REL_PATH"
+        mkdir -p "$(dirname "$AGENT_DIR/$DST_REL")"
+        cp "$FILE_PATH" "$AGENT_DIR/$DST_REL"
         exit 0
         ;;
     esac


### PR DESCRIPTION
## Summary
- **Skills system**: Local skills (`.toc/skills/`) and URL-based skills (stored as references in `skills.yaml`, resolved fresh at spawn time for always up-to-date versions)
- **Agent integration**: Skills field in `oc-agent.yaml`, `toc agent skills <name>` multi-select TUI for toggling, skills shown per agent in `toc status`
- **Session provisioning**: `agent.md` → `CLAUDE.md` conversion at spawn time; skills resolved into `.claude/skills/` so Claude Code discovers them natively
- **CLI commands**: `toc skill create`, `toc skill add <url>`, `toc skill list`, `toc skill remove`
- **Validation**: Follows agentskills.io spec — SKILL.md frontmatter with required `name`/`description`, name format rules, SKILL.md discovery at repo root or one level deep

## Test plan
- [ ] `toc skill create` — interactive TUI creates local skill with valid SKILL.md
- [ ] `toc skill add <url>` — validates remote repo has SKILL.md, stores reference
- [ ] `toc skill list` — shows local and URL skills with types
- [ ] `toc agent skills <name>` — multi-select toggles skills on/off for agent
- [ ] `toc agent spawn` — resolves skills into session `.claude/skills/`, warns on failures
- [ ] `toc status` — shows skills per agent and lists all available skills
- [ ] Failed skills show warning at spawn and post-session with remediation guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)