### PR TITLE
Add binary releases and curl install

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+version: 2
+
+builds:
+  - binary: toc
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/tiny-oc/toc/cmd.version={{.Version}}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "toc_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+release:
+  github:
+    owner: tiny-oc
+    name: toc

--- a/README.md
+++ b/README.md
@@ -7,13 +7,23 @@ Define agents as simple YAML configs, then spawn isolated sessions instantly. Bu
 ## Install
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/tiny-oc/toc/main/get-toc.sh | bash
+```
+
+Downloads the latest prebuilt binary for your platform. Supports macOS and Linux (amd64/arm64).
+
+Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to spawn agent sessions.
+
+### Build from source
+
+```bash
 git clone https://github.com/tiny-oc/toc.git
 cd toc
 make build
 ./install.sh
 ```
 
-Requires [Go 1.25+](https://go.dev/dl/) and [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+Requires [Go 1.25+](https://go.dev/dl/).
 
 ## Quick start
 

--- a/get-toc.sh
+++ b/get-toc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="https://github.com/tiny-oc/toc.git"
+REPO="tiny-oc/toc"
 INSTALL_DIR="/usr/local/bin"
 FALLBACK_DIR="$HOME/.local/bin"
 BIN_NAME="toc"
@@ -9,40 +9,76 @@ BIN_NAME="toc"
 echo "Installing toc..."
 echo ""
 
-# Check dependencies
-if ! command -v go &>/dev/null; then
-  echo "Error: Go is required but not installed."
-  echo "Install it from https://go.dev/dl/"
+# Detect platform
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  arm64)   ARCH="arm64" ;;
+  *)
+    echo "Error: unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+case "$OS" in
+  darwin|linux) ;;
+  *)
+    echo "Error: unsupported OS: $OS"
+    echo "Supported: darwin (macOS), linux"
+    exit 1
+    ;;
+esac
+
+echo "Platform: ${OS}/${ARCH}"
+
+# Resolve latest version
+if ! command -v curl &>/dev/null; then
+  echo "Error: curl is required but not installed."
   exit 1
 fi
 
-if ! command -v git &>/dev/null; then
-  echo "Error: git is required but not installed."
+VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+
+if [ -z "$VERSION" ]; then
+  echo "Error: could not determine latest version."
+  echo "Check https://github.com/${REPO}/releases for available releases."
   exit 1
 fi
 
-# Clone to temp directory
+echo "Version: v${VERSION}"
+
+# Download and extract
+ARCHIVE="toc_${VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-echo "Cloning repository..."
-git clone --depth 1 "$REPO" "$TMPDIR" 2>/dev/null
+echo "Downloading ${ARCHIVE}..."
+if ! curl -fsSL "$URL" -o "${TMPDIR}/${ARCHIVE}"; then
+  echo "Error: failed to download ${URL}"
+  echo "Check https://github.com/${REPO}/releases for available binaries."
+  exit 1
+fi
 
-echo "Building..."
-cd "$TMPDIR"
-go build -o "bin/$BIN_NAME" .
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
 
 # Install binary
-if cp "bin/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME" 2>/dev/null; then
-  echo "Installed to $INSTALL_DIR/$BIN_NAME"
+chmod +x "${TMPDIR}/${BIN_NAME}"
+
+if cp "${TMPDIR}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}" 2>/dev/null; then
+  echo "Installed to ${INSTALL_DIR}/${BIN_NAME}"
 else
   mkdir -p "$FALLBACK_DIR"
-  cp "bin/$BIN_NAME" "$FALLBACK_DIR/$BIN_NAME"
-  echo "Installed to $FALLBACK_DIR/$BIN_NAME"
+  cp "${TMPDIR}/${BIN_NAME}" "${FALLBACK_DIR}/${BIN_NAME}"
+  echo "Installed to ${FALLBACK_DIR}/${BIN_NAME}"
   if [[ ":$PATH:" != *":$FALLBACK_DIR:"* ]]; then
     echo ""
-    echo "Add $FALLBACK_DIR to your PATH:"
-    echo "  export PATH=\"$FALLBACK_DIR:\$PATH\""
+    echo "Add ${FALLBACK_DIR} to your PATH:"
+    echo "  export PATH=\"${FALLBACK_DIR}:\$PATH\""
   fi
 fi
 


### PR DESCRIPTION
## Summary
- GoReleaser config for cross-platform binaries (darwin/linux, amd64/arm64)
- GitHub Actions workflow triggers on `v*` tags
- `get-toc.sh` rewritten to download prebuilt binary (no Go required)
- README install section updated with curl one-liner

## How to release
```bash
git tag v0.1.0
git push origin v0.1.0
```

## Test plan
- [ ] Tag a release and verify GitHub Actions builds binaries
- [ ] `curl -fsSL https://raw.githubusercontent.com/tiny-oc/toc/main/get-toc.sh | bash` installs correctly
- [ ] Verify darwin/arm64, darwin/amd64, linux/amd64 archives are present in the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)