### PR TITLE
Fix repo URLs to louismorgner/tiny-oc

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,5 +30,5 @@ changelog:
 
 release:
   github:
-    owner: tiny-oc
-    name: toc
+    owner: louismorgner
+    name: tiny-oc

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Define agents as simple YAML configs, then spawn isolated sessions instantly. Bu
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tiny-oc/toc/main/get-toc.sh | bash
+curl -fsSL https://raw.githubusercontent.com/louismorgner/tiny-oc/main/get-toc.sh | bash
 ```
 
 Downloads the latest prebuilt binary for your platform. Supports macOS and Linux (amd64/arm64).
@@ -17,7 +17,7 @@ Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to spawn 
 ### Build from source
 
 ```bash
-git clone https://github.com/tiny-oc/toc.git
+git clone https://github.com/louismorgner/tiny-oc.git
 cd toc
 make build
 ./install.sh

--- a/get-toc.sh
+++ b/get-toc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="tiny-oc/toc"
+REPO="louismorgner/tiny-oc"
 INSTALL_DIR="/usr/local/bin"
 FALLBACK_DIR="$HOME/.local/bin"
 BIN_NAME="toc"

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	RepoURL  = "https://github.com/tiny-oc/toc.git"
-	IndexURL = "https://raw.githubusercontent.com/tiny-oc/toc/main/registry/skills/index.yaml"
+	RepoURL  = "https://github.com/louismorgner/tiny-oc.git"
+	IndexURL = "https://raw.githubusercontent.com/louismorgner/tiny-oc/main/registry/skills/index.yaml"
 )
 
 // SkillEntry represents a skill in the registry index.


### PR DESCRIPTION
## Summary
- Fixes all GitHub URLs that incorrectly referenced `tiny-oc/toc` instead of `louismorgner/tiny-oc`
- Affects: get-toc.sh, .goreleaser.yaml, registry constants, README

🤖 Generated with [Claude Code](https://claude.com/claude-code)