### PR TITLE
Unify registry — search and install skills and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ When you run `toc agent spawn`, it:
 | `toc skill create` | Create a new local skill |
 | `toc skill list` | List available skills |
 | `toc skill add <url>` | Install a skill from a Git URL |
-| `toc skill add --registry <name>` | Install a skill from the registry |
 | `toc skill remove <name>` | Remove a skill |
-| `toc registry search [query]` | Browse skills in the registry |
+| `toc registry search [query]` | Browse skills and agent templates |
+| `toc registry install <name>` | Install a skill or agent from the registry |
 | `toc audit` | View the audit log |
 | `toc completion <shell>` | Generate shell completion script |
 
@@ -90,8 +90,7 @@ When you run `toc agent spawn`, it:
 - [x] Context sync — persist session outputs back to agent templates
 - [x] Audit log — append-only JSON Lines log for compliance and traceability
 - [x] Skills — reusable, shareable agent capabilities
-- [ ] Skills registry — browsable catalog of installable skills
-- [ ] Agent registry — browsable catalog of agent templates
+- [x] Registry — unified catalog of skills and agent templates with search and install
 - [ ] Sub-agents — agents that spawn and coordinate other agents
 - [ ] Cost controls — per-agent and per-session spending limits
 - [ ] Integrations and permissions — connect agents to external tools with scoped access

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -41,8 +41,9 @@ var initCmd = &cobra.Command{
 		ui.Success("Initialized workspace %s", ui.Bold(name))
 		fmt.Println()
 		ui.Info("Next steps:")
-		ui.Info("  %s  Create a new agent from scratch", ui.Bold("toc agent create"))
-		ui.Info("  %s  Browse agent templates from the registry", ui.Bold("toc registry search"))
+		ui.Info("  %s       Create a new agent from scratch", ui.Bold("toc agent create"))
+		ui.Info("  %s     Browse the registry for templates", ui.Bold("toc registry search"))
+		ui.Info("  %s  Install an agent or skill template", ui.Bold("toc registry install <name>"))
 		fmt.Println()
 		return nil
 	},

--- a/cmd/registry_install.go
+++ b/cmd/registry_install.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/audit"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/registry"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	registryCmd.AddCommand(registryInstallCmd)
+}
+
+var registryInstallCmd = &cobra.Command{
+	Use:   "install <name>",
+	Short: "Install a skill or agent template from the registry",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		name := args[0]
+
+		ui.Info("Fetching registry...")
+		index, err := registry.FetchIndex()
+		if err != nil {
+			return err
+		}
+
+		entry, found := registry.Find(index, name)
+		if !found {
+			return fmt.Errorf("'%s' not found in registry — run 'toc registry search' to see what's available", name)
+		}
+
+		ui.Info("Installing %s %s — %s", entry.Type, ui.Bold(entry.Name), ui.Dim(entry.Description))
+
+		if err := registry.Install(entry); err != nil {
+			return err
+		}
+
+		_ = audit.Log("registry.install", map[string]interface{}{
+			"name": entry.Name,
+			"type": entry.Type,
+		})
+
+		fmt.Println()
+		switch entry.Type {
+		case "agent":
+			ui.Success("Installed agent %s", ui.Bold(entry.Name))
+			if len(entry.Skills) > 0 {
+				ui.Info("Skills installed: %s", ui.Dim(strings.Join(entry.Skills, ", ")))
+			}
+			ui.Info("Spawn with: %s", ui.Bold(fmt.Sprintf("toc agent spawn %s", entry.Name)))
+		case "skill":
+			ui.Success("Installed skill %s", ui.Bold(entry.Name))
+			ui.Info("Assign to an agent with: %s", ui.Bold("toc agent skills <agent-name>"))
+		}
+		fmt.Println()
+		return nil
+	},
+}

--- a/cmd/registry_search.go
+++ b/cmd/registry_search.go
@@ -18,10 +18,10 @@ func init() {
 
 var registrySearchCmd = &cobra.Command{
 	Use:   "search [query]",
-	Short: "Search for skills in the registry",
+	Short: "Browse skills and agent templates in the registry",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Info("Fetching registry index...")
+		ui.Info("Fetching registry...")
 
 		index, err := registry.FetchIndex()
 		if err != nil {
@@ -45,28 +45,36 @@ var registrySearchCmd = &cobra.Command{
 		}
 
 		if len(results) == 0 {
-			ui.Warn("No skills found matching '%s'", query)
+			if query != "" {
+				ui.Warn("No results for '%s'", query)
+			} else {
+				ui.Warn("Registry is empty")
+			}
 			return nil
 		}
 
 		fmt.Println()
-		fmt.Printf("  %-20s %-12s %s\n", ui.Bold("NAME"), ui.Bold("TAGS"), ui.Bold("DESCRIPTION"))
-		fmt.Printf("  %-20s %-12s %s\n", ui.Dim("────────────────────"), ui.Dim("────────────"), ui.Dim("───────────────────────────────"))
+		fmt.Printf("  %-20s %-8s %s\n", ui.Bold("NAME"), ui.Bold("TYPE"), ui.Bold("DESCRIPTION"))
+		fmt.Printf("  %-20s %-8s %s\n", ui.Dim("────────────────────"), ui.Dim("────────"), ui.Dim("───────────────────────────────────────"))
 
-		for _, s := range results {
-			tags := ""
-			if len(s.Tags) > 0 {
-				tags = strings.Join(s.Tags, ", ")
-			}
-			desc := s.Description
+		for _, e := range results {
+			desc := e.Description
 			if len(desc) > 50 {
 				desc = desc[:47] + "..."
 			}
-			fmt.Printf("  %-20s %-12s %s\n", ui.Cyan(s.Name), ui.Dim(tags), desc)
+			typeBadge := ui.Dim(e.Type)
+			if e.Type == "agent" {
+				extra := []string{e.Model}
+				if len(e.Skills) > 0 {
+					extra = append(extra, fmt.Sprintf("%d skill(s)", len(e.Skills)))
+				}
+				desc = fmt.Sprintf("%s %s", desc, ui.Dim("["+strings.Join(extra, ", ")+"]"))
+			}
+			fmt.Printf("  %-20s %-8s %s\n", ui.Cyan(e.Name), typeBadge, desc)
 		}
 
 		fmt.Println()
-		ui.Info("Install with: %s", ui.Bold("toc skill add --registry <name>"))
+		ui.Info("Install with: %s", ui.Bold("toc registry install <name>"))
 		fmt.Println()
 		return nil
 	},

--- a/cmd/skill_add.go
+++ b/cmd/skill_add.go
@@ -9,122 +9,71 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tiny-oc/toc/internal/audit"
 	"github.com/tiny-oc/toc/internal/config"
-	"github.com/tiny-oc/toc/internal/registry"
 	"github.com/tiny-oc/toc/internal/skill"
 	"github.com/tiny-oc/toc/internal/ui"
 )
 
-var skillAddRegistry bool
-
 func init() {
-	skillAddCmd.Flags().BoolVar(&skillAddRegistry, "registry", false, "Install from the toc skill registry")
 	skillCmd.AddCommand(skillAddCmd)
 }
 
 var skillAddCmd = &cobra.Command{
-	Use:   "add <url-or-name>",
-	Short: "Add a skill from a URL or the registry",
+	Use:   "add <url>",
+	Short: "Add a skill from a public Git repository",
+	Long:  "Add a skill from a Git URL. To install from the registry, use: toc registry install <name>",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := config.EnsureInitialized(); err != nil {
 			return err
 		}
 
-		arg := args[0]
-
-		if skillAddRegistry {
-			return addFromRegistry(arg)
+		url := args[0]
+		if !skill.IsURL(url) {
+			return fmt.Errorf("expected a URL (https://...)\n\nTo install from the registry: toc registry install %s", url)
 		}
 
-		if skill.IsURL(arg) {
-			return addFromURL(arg)
+		ui.Info("Validating skill at %s...", ui.Dim(url))
+
+		tmpDir, err := os.MkdirTemp("", "toc-skill-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp directory: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		gitCmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
+		gitCmd.Stdout = io.Discard
+		gitCmd.Stderr = io.Discard
+		if err := gitCmd.Run(); err != nil {
+			return fmt.Errorf("failed to clone repository — is the URL correct and public?")
 		}
 
-		return fmt.Errorf("expected a URL (https://...) or use --registry flag to install by name\n\nExamples:\n  toc skill add https://github.com/user/skill-repo\n  toc skill add --registry code-review")
+		skillDir, err := skill.FindSkillMDInDir(tmpDir)
+		if err != nil {
+			return err
+		}
+
+		meta, err := skill.ValidateSkillDir(skillDir)
+		if err != nil {
+			return err
+		}
+
+		if skill.Exists(meta.Name) {
+			return fmt.Errorf("a local skill named '%s' already exists — remove it first or use a different name", meta.Name)
+		}
+
+		if err := skill.AddRef(skill.SkillRef{Name: meta.Name, URL: url}); err != nil {
+			return err
+		}
+
+		_ = audit.Log("skill.add", map[string]interface{}{
+			"skill": meta.Name,
+			"url":   url,
+		})
+
+		fmt.Println()
+		ui.Success("Added skill %s from %s", ui.Bold(meta.Name), ui.Dim(url))
+		ui.Info("This skill will be resolved fresh from the URL each time an agent session is spawned.")
+		fmt.Println()
+		return nil
 	},
-}
-
-func addFromRegistry(name string) error {
-	if err := skill.ValidateName(name); err != nil {
-		return err
-	}
-
-	if skill.Exists(name) {
-		return fmt.Errorf("skill '%s' already exists locally — remove it first with: toc skill remove %s", name, name)
-	}
-
-	ui.Info("Fetching registry index...")
-	index, err := registry.FetchIndex()
-	if err != nil {
-		return err
-	}
-
-	entry, found := registry.FindSkill(index, name)
-	if !found {
-		return fmt.Errorf("skill '%s' not found in registry — run 'toc registry search' to see available skills", name)
-	}
-
-	ui.Info("Installing %s — %s", ui.Bold(entry.Name), ui.Dim(entry.Description))
-
-	meta, err := registry.InstallSkill(name)
-	if err != nil {
-		return err
-	}
-
-	_ = audit.Log("skill.add", map[string]interface{}{
-		"skill":  meta.Name,
-		"source": "registry",
-	})
-
-	fmt.Println()
-	ui.Success("Installed skill %s from registry", ui.Bold(meta.Name))
-	ui.Info("Assign it to an agent with: %s", ui.Bold(fmt.Sprintf("toc agent skills <agent-name>")))
-	fmt.Println()
-	return nil
-}
-
-func addFromURL(url string) error {
-	ui.Info("Validating skill at %s...", ui.Dim(url))
-
-	tmpDir, err := os.MkdirTemp("", "toc-skill-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	gitCmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
-	gitCmd.Stdout = io.Discard
-	gitCmd.Stderr = io.Discard
-	if err := gitCmd.Run(); err != nil {
-		return fmt.Errorf("failed to clone repository — is the URL correct and public?")
-	}
-
-	skillDir, err := skill.FindSkillMDInDir(tmpDir)
-	if err != nil {
-		return err
-	}
-
-	meta, err := skill.ValidateSkillDir(skillDir)
-	if err != nil {
-		return err
-	}
-
-	if skill.Exists(meta.Name) {
-		return fmt.Errorf("a local skill named '%s' already exists — remove it first or use a different name", meta.Name)
-	}
-
-	if err := skill.AddRef(skill.SkillRef{Name: meta.Name, URL: url}); err != nil {
-		return err
-	}
-
-	_ = audit.Log("skill.add", map[string]interface{}{
-		"skill": meta.Name,
-		"url":   url,
-	})
-
-	fmt.Println()
-	ui.Success("Added skill %s from %s", ui.Bold(meta.Name), ui.Dim(url))
-	ui.Info("This skill will be resolved fresh from the URL each time an agent session is spawned.")
-	fmt.Println()
-	return nil
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,64 +10,102 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tiny-oc/toc/internal/agent"
 	"github.com/tiny-oc/toc/internal/skill"
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	RepoURL  = "https://github.com/louismorgner/tiny-oc.git"
-	IndexURL = "https://raw.githubusercontent.com/louismorgner/tiny-oc/main/registry/skills/index.yaml"
+	RepoURL        = "https://github.com/louismorgner/tiny-oc.git"
+	rawBase        = "https://raw.githubusercontent.com/louismorgner/tiny-oc/main/registry"
+	SkillIndexURL  = rawBase + "/skills/index.yaml"
+	AgentIndexURL  = rawBase + "/agents/index.yaml"
 )
 
-// SkillEntry represents a skill in the registry index.
-type SkillEntry struct {
+// Entry represents any item in the registry — skill or agent.
+type Entry struct {
 	Name        string   `yaml:"name" json:"name"`
 	Description string   `yaml:"description" json:"description"`
+	Type        string   `yaml:"-" json:"type"` // "skill" or "agent"
 	Tags        []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Model       string   `yaml:"model,omitempty" json:"model,omitempty"`
+	Skills      []string `yaml:"skills,omitempty" json:"skills,omitempty"`
 }
 
-// SkillIndex is the top-level registry index.
-type SkillIndex struct {
-	Skills []SkillEntry `yaml:"skills" json:"skills"`
+type skillIndex struct {
+	Skills []Entry `yaml:"skills"`
 }
 
-// FetchIndex downloads and parses the skills registry index from GitHub.
-func FetchIndex() (*SkillIndex, error) {
-	resp, err := http.Get(IndexURL)
+type agentIndex struct {
+	Agents []Entry `yaml:"agents"`
+}
+
+// Index holds all registry entries.
+type Index struct {
+	Entries []Entry
+}
+
+// FetchIndex downloads both skill and agent indexes and merges them.
+func FetchIndex() (*Index, error) {
+	index := &Index{}
+
+	skills, err := fetchYAML[skillIndex](SkillIndexURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch registry index: %w", err)
+		return nil, fmt.Errorf("failed to fetch skills index: %w", err)
+	}
+	for _, s := range skills.Skills {
+		s.Type = "skill"
+		index.Entries = append(index.Entries, s)
+	}
+
+	agents, err := fetchYAML[agentIndex](AgentIndexURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch agents index: %w", err)
+	}
+	for _, a := range agents.Agents {
+		a.Type = "agent"
+		index.Entries = append(index.Entries, a)
+	}
+
+	return index, nil
+}
+
+func fetchYAML[T any](url string) (*T, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch registry index: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
 	}
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read registry index: %w", err)
+		return nil, err
 	}
 
-	var index SkillIndex
-	if err := yaml.Unmarshal(data, &index); err != nil {
-		return nil, fmt.Errorf("failed to parse registry index: %w", err)
+	var result T
+	if err := yaml.Unmarshal(data, &result); err != nil {
+		return nil, err
 	}
-
-	return &index, nil
+	return &result, nil
 }
 
-// Search filters the index by a query string, matching against name, description, and tags.
-func Search(index *SkillIndex, query string) []SkillEntry {
+// Search filters entries by query, matching name, description, tags, and type.
+func Search(index *Index, query string) []Entry {
 	if query == "" {
-		return index.Skills
+		return index.Entries
 	}
 	q := strings.ToLower(query)
-	var results []SkillEntry
-	for _, s := range index.Skills {
-		if strings.Contains(strings.ToLower(s.Name), q) ||
-			strings.Contains(strings.ToLower(s.Description), q) ||
-			matchTags(s.Tags, q) {
-			results = append(results, s)
+	var results []Entry
+	for _, e := range index.Entries {
+		if strings.Contains(strings.ToLower(e.Name), q) ||
+			strings.Contains(strings.ToLower(e.Description), q) ||
+			strings.Contains(e.Type, q) ||
+			matchTags(e.Tags, q) {
+			results = append(results, e)
 		}
 	}
 	return results
@@ -82,66 +120,118 @@ func matchTags(tags []string, query string) bool {
 	return false
 }
 
-// FindSkill looks up a skill by exact name in the index.
-func FindSkill(index *SkillIndex, name string) (*SkillEntry, bool) {
-	for _, s := range index.Skills {
-		if s.Name == name {
-			return &s, true
+// Find looks up an entry by exact name.
+func Find(index *Index, name string) (*Entry, bool) {
+	for _, e := range index.Entries {
+		if e.Name == name {
+			return &e, true
 		}
 	}
 	return nil, false
 }
 
-// InstallSkill clones the toc repo and copies the skill into the local workspace (.toc/skills/).
-func InstallSkill(name string) (*skill.SkillMeta, error) {
-	return InstallSkillTo(name, skill.Dir(name))
+// FindSkill looks up a skill by exact name (for backward compat with spawn resolution).
+func FindSkill(index *Index, name string) (*Entry, bool) {
+	for _, e := range index.Entries {
+		if e.Name == name && e.Type == "skill" {
+			return &e, true
+		}
+	}
+	return nil, false
 }
 
-// InstallSkillTo clones the toc repo and copies the skill into the given target directory.
-// Used by both `toc skill add --registry` (installs to .toc/skills/) and spawn-time
-// resolution (installs to session .claude/skills/).
+// Install installs a registry entry into the local workspace.
+// For skills: copies to .toc/skills/<name>/
+// For agents: copies to .toc/agents/<name>/ and installs referenced skills
+func Install(entry *Entry) error {
+	switch entry.Type {
+	case "skill":
+		return installSkill(entry.Name)
+	case "agent":
+		return installAgent(entry)
+	default:
+		return fmt.Errorf("unknown registry entry type: %s", entry.Type)
+	}
+}
+
+func installSkill(name string) error {
+	if skill.Exists(name) {
+		return fmt.Errorf("skill '%s' already exists locally", name)
+	}
+	_, err := InstallSkillTo(name, skill.Dir(name))
+	return err
+}
+
+func installAgent(entry *Entry) error {
+	if agent.Exists(entry.Name) {
+		return fmt.Errorf("agent '%s' already exists locally", entry.Name)
+	}
+
+	destDir := agent.Dir(entry.Name)
+	if err := cloneRegistryDir("agents/"+entry.Name, destDir); err != nil {
+		return err
+	}
+
+	// Install referenced skills that aren't already local
+	for _, s := range entry.Skills {
+		if skill.Exists(s) {
+			continue
+		}
+		if _, err := InstallSkillTo(s, skill.Dir(s)); err != nil {
+			return fmt.Errorf("failed to install skill '%s' referenced by agent: %w", s, err)
+		}
+	}
+
+	return nil
+}
+
+// InstallSkillTo clones a skill from the registry into the given directory.
 func InstallSkillTo(name, destDir string) (*skill.SkillMeta, error) {
-	tmpDir, err := os.MkdirTemp("", "toc-registry-*")
+	if err := cloneRegistryDir("skills/"+name, destDir); err != nil {
+		return nil, err
+	}
+
+	meta, err := skill.ValidateSkillDir(destDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Sparse clone — only fetch the specific skill directory
-	gitCmd := exec.Command("git", "clone", "--depth", "1", "--filter=blob:none", "--sparse", RepoURL, tmpDir)
-	gitCmd.Stdout = io.Discard
-	gitCmd.Stderr = io.Discard
-	if err := gitCmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to clone registry repository")
-	}
-
-	sparseCmd := exec.Command("git", "-C", tmpDir, "sparse-checkout", "set", fmt.Sprintf("registry/skills/%s", name))
-	sparseCmd.Stdout = io.Discard
-	sparseCmd.Stderr = io.Discard
-	if err := sparseCmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to configure sparse checkout")
-	}
-
-	// Validate the skill
-	skillSrc := filepath.Join(tmpDir, "registry", "skills", name)
-	if _, err := os.Stat(skillSrc); os.IsNotExist(err) {
-		return nil, fmt.Errorf("skill '%s' not found in registry", name)
-	}
-
-	meta, err := skill.ValidateSkillDir(skillSrc)
-	if err != nil {
+		os.RemoveAll(destDir)
 		return nil, fmt.Errorf("invalid skill in registry: %w", err)
-	}
-
-	if err := copyDir(skillSrc, destDir); err != nil {
-		return nil, fmt.Errorf("failed to install skill: %w", err)
 	}
 
 	return meta, nil
 }
 
-// FormatJSON returns the index as formatted JSON (for --json flag).
-func FormatJSON(entries []SkillEntry) (string, error) {
+// cloneRegistryDir does a sparse clone of a specific directory from the registry.
+func cloneRegistryDir(registryPath, destDir string) error {
+	tmpDir, err := os.MkdirTemp("", "toc-registry-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	gitCmd := exec.Command("git", "clone", "--depth", "1", "--filter=blob:none", "--sparse", RepoURL, tmpDir)
+	gitCmd.Stdout = io.Discard
+	gitCmd.Stderr = io.Discard
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to clone registry repository")
+	}
+
+	sparseCmd := exec.Command("git", "-C", tmpDir, "sparse-checkout", "set", "registry/"+registryPath)
+	sparseCmd.Stdout = io.Discard
+	sparseCmd.Stderr = io.Discard
+	if err := sparseCmd.Run(); err != nil {
+		return fmt.Errorf("failed to configure sparse checkout")
+	}
+
+	srcDir := filepath.Join(tmpDir, "registry", registryPath)
+	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+		return fmt.Errorf("'%s' not found in registry", registryPath)
+	}
+
+	return copyDir(srcDir, destDir)
+}
+
+// FormatJSON returns entries as formatted JSON.
+func FormatJSON(entries []Entry) (string, error) {
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- `toc registry search` now shows both skills and agents with TYPE column
- `toc registry install <name>` installs either type, auto-detecting from the index
  - Agent install copies template + auto-installs referenced skills
- Removed `--registry` flag from `toc skill add` (redundant with `registry install`)
- Updated init next-steps and README commands table
- Checked off registry in roadmap

## CLI changes
```
toc registry search           # browse everything
toc registry search cto       # filter by query
toc registry install cto      # installs agent + its skills
toc registry install open-source-cto  # installs just the skill
toc skill add <url>           # unchanged, for Git URL skills
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)