### PR TITLE
Session status tracking and skip-permissions default

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -100,7 +100,17 @@ var statusCmd = &cobra.Command{
 			fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d total)", len(sf.Sessions))))
 			for _, s := range shown {
 				age := timeAgo(s.CreatedAt)
-				fmt.Printf("    %s %s  %s  %s\n", ui.Dim("▪"), ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
+				status := s.ResolvedStatus()
+				var badge string
+				switch status {
+				case "active":
+					badge = ui.Green("● active")
+				case "completed":
+					badge = ui.Dim("○ completed")
+				case "stale":
+					badge = ui.Yellow("◌ stale")
+				}
+				fmt.Printf("    %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
 			}
 		}
 		fmt.Println()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,11 +9,47 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	StatusActive    = "active"
+	StatusCompleted = "completed"
+)
+
 type Session struct {
 	ID            string    `yaml:"id"`
 	Agent         string    `yaml:"agent"`
 	CreatedAt     time.Time `yaml:"created_at"`
 	WorkspacePath string    `yaml:"workspace_path"`
+	Status        string    `yaml:"status,omitempty"`
+}
+
+// ResolvedStatus returns the display status, checking workspace existence.
+func (s *Session) ResolvedStatus() string {
+	if _, err := os.Stat(s.WorkspacePath); os.IsNotExist(err) {
+		return "stale"
+	}
+	if s.Status == StatusActive {
+		return "active"
+	}
+	if s.Status == StatusCompleted {
+		return "completed"
+	}
+	// Legacy sessions without status field
+	return "completed"
+}
+
+// UpdateStatus sets the status of a session by ID.
+func UpdateStatus(id, status string) error {
+	sf, err := Load()
+	if err != nil {
+		return err
+	}
+	for i := range sf.Sessions {
+		if sf.Sessions[i].ID == id {
+			sf.Sessions[i].Status = status
+			return Save(sf)
+		}
+	}
+	return fmt.Errorf("session '%s' not found", id)
 }
 
 type SessionsFile struct {

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -66,6 +66,7 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 		Agent:         cfg.Name,
 		CreatedAt:     time.Now(),
 		WorkspacePath: workDir,
+		Status:        session.StatusActive,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to track session: %w", err)
 	}
@@ -85,6 +86,7 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 	fmt.Println()
 
 	_ = launchClaude(workDir, cfg.Model, sessionID, false)
+	_ = session.UpdateStatus(sessionID, session.StatusCompleted)
 
 	// Post-session sync: copy matching files back to agent template
 	var syncedFiles int
@@ -136,7 +138,9 @@ func ResumeSession(s *session.Session) (*SpawnResult, error) {
 	}
 	fmt.Println()
 
+	_ = session.UpdateStatus(s.ID, session.StatusActive)
 	_ = launchClaude(s.WorkspacePath, cfg.Model, s.ID, true)
+	_ = session.UpdateStatus(s.ID, session.StatusCompleted)
 
 	var syncedFiles int
 	if len(cfg.Context) > 0 {
@@ -195,7 +199,7 @@ func printResumeCommand(agentName, sessionID string) {
 }
 
 func launchClaude(dir, model, sessionID string, resume bool) error {
-	args := []string{}
+	args := []string{"--dangerously-skip-permissions"}
 	if model != "" {
 		args = append(args, "--model", model)
 	}


### PR DESCRIPTION
## Summary
- Sessions track status: active → completed, stale if workspace is gone
- `toc status` shows colored badges (● active, ○ completed, ◌ stale)
- Claude Code sessions launch with `--dangerously-skip-permissions` by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)