### PR TITLE
Add on_end config for session end hooks

### DIFF
--- a/.claude/skills/toc-dev/SKILL.md
+++ b/.claude/skills/toc-dev/SKILL.md
@@ -37,7 +37,7 @@ internal/
 ## Key data structures
 
 **AgentConfig** (`internal/agent/agent.go`):
-- Fields: Runtime, Name, Description, Model, Context (glob patterns)
+- Fields: Runtime, Name, Description, Model, Context (glob patterns), OnEnd (session end prompt)
 - Stored as `.toc/agents/<name>/oc-agent.yaml`
 - Validate() checks runtime (claude-code), model (sonnet/opus/haiku), name format
 
@@ -54,8 +54,9 @@ internal/
 1. `spawn.SpawnSession()` creates a temp dir at `/tmp/toc-sessions/<name>-<timestamp>/`
 2. Copies the entire agent template directory into it
 3. If the agent has `context:` patterns, generates `.claude/settings.json` with a PostToolUse hook and `.claude/toc-sync.sh` — this syncs matching files back to the agent template in real-time
-4. Launches `claude` CLI with `--model` and `--session-id` flags
-5. After session ends, runs a post-session sync pass as a safety net
+4. If the agent has `on_end:`, adds a SessionEnd hook with an agent-type handler that runs the prompt with tool access before the session fully closes
+5. Launches `claude` CLI with `--model` and `--session-id` flags
+6. After session ends, runs a post-session sync pass as a safety net
 6. Prints resume command
 
 ## Context sync system
@@ -63,6 +64,10 @@ internal/
 The `context:` field in `oc-agent.yaml` defines glob patterns for files that should be synced back from temp sessions to the agent template. Supports: `*.md`, `docs/`, `context/**/*.md`, bare filenames. Pattern matching is in `internal/sync/sync.go` with tests in `sync_test.go`.
 
 Real-time sync uses Claude Code's PostToolUse hook (fires on Edit/Write/MultiEdit). Post-session sync walks the session dir as a fallback.
+
+## Session end hook
+
+The `on_end:` field in `oc-agent.yaml` configures a SessionEnd hook with an agent-type handler. The prompt is evaluated by Claude with tool access when the session ends, allowing it to write files before closing. Works independently of context sync — can be used alone or combined with `context:` patterns.
 
 ## Development workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,13 @@ toc agent spawn pr-reviewer
 │                  │  Matching files copied back to agent template
 └───────┬─────────┘
         │
-        ▼  (session ends)
+        ▼  (session ending, if on_end configured)
+┌─────────────────┐
+│  Session end     │  SessionEnd hook runs on_end prompt with tool access
+│  hook            │  Agent persists context before session closes
+└───────┬─────────┘
+        │
+        ▼  (session closed)
 ┌─────────────────┐
 │  Post-session    │  Final sync pass copies any remaining matches
 │  sync            │  Session recorded in .toc/sessions.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,9 @@ context:
 skills:
   - code-review
   - https://github.com/example/my-skill.git
+on_end: >
+  Save a concise summary of decisions made, open questions, and
+  key learnings from this session to context/session-notes.md.
 ```
 
 ### Fields
@@ -39,6 +42,7 @@ skills:
 | `model` | string | yes | — | Claude model: `sonnet`, `opus`, or `haiku` |
 | `context` | list | no | — | Glob patterns for context sync (see below) |
 | `skills` | list | no | — | Skill names (local) or Git URLs (remote) |
+| `on_end` | string | no | — | Prompt run as a Claude Code `SessionEnd` hook (see below) |
 
 ### Agent instructions
 
@@ -72,6 +76,23 @@ When a session is spawned, toc generates:
 - `.claude/settings.json` — registers the sync script as a PostToolUse hook
 
 These are created in the session's temp directory and do not affect your project.
+
+## Session end hook
+
+The `on_end` field lets you define a prompt that runs automatically when a Claude Code session ends. It uses Claude Code's `SessionEnd` hook with an `agent`-type handler, meaning the prompt is evaluated by Claude with full tool access — it can read, write, and edit files before the session fully closes.
+
+This is useful for persisting context that the agent might not save on its own during the session. For example, you can ask it to write a summary, update a knowledge base, or capture decisions.
+
+```yaml
+on_end: >
+  Review what happened in this session. Save a concise summary of
+  decisions, open questions, and anything worth remembering to
+  context/session-notes.md. Append to the file if it already exists.
+```
+
+The prompt is written directly in your agent config — use it to describe what you want persisted and where. When combined with `context` patterns, any files the hook writes that match a pattern will be synced back to the agent template by the post-session sync pass.
+
+`on_end` works independently of `context` — you can use it without context sync patterns if you just want end-of-session behavior without bidirectional file sync.
 
 ## Session storage
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,6 +20,7 @@ type AgentConfig struct {
 	Context     []string `yaml:"context,omitempty"`
 	Skills      []string `yaml:"skills,omitempty"`
 	SubAgents   []string `yaml:"sub-agents,omitempty"`
+	OnEnd       string   `yaml:"on_end,omitempty"`
 }
 
 // CanSpawn checks if this agent is allowed to spawn the given target agent.

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -56,8 +56,12 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 	}
 
 	if len(cfg.Context) > 0 {
-		if err := setupContextHooks(workDir, srcDir, cfg.Context); err != nil {
+		if err := setupContextHooks(workDir, srcDir, cfg.Context, cfg.OnEnd); err != nil {
 			return nil, fmt.Errorf("failed to setup context sync hooks: %w", err)
+		}
+	} else if cfg.OnEnd != "" {
+		if err := setupOnEndHook(workDir, cfg.OnEnd); err != nil {
+			return nil, fmt.Errorf("failed to setup on_end hook: %w", err)
 		}
 	}
 
@@ -82,6 +86,9 @@ func SpawnSession(cfg *agent.AgentConfig) (*SpawnResult, error) {
 	}
 	if len(cfg.Context) > 0 {
 		ui.Info("Context sync: %s", ui.Dim(fmt.Sprintf("%d pattern(s)", len(cfg.Context))))
+	}
+	if cfg.OnEnd != "" {
+		ui.Info("On end: %s", ui.Dim("session end hook enabled"))
 	}
 	fmt.Println()
 
@@ -123,8 +130,12 @@ func ResumeSession(s *session.Session) (*SpawnResult, error) {
 
 	// Re-setup hooks in case they were cleaned up
 	if len(cfg.Context) > 0 {
-		if err := setupContextHooks(s.WorkspacePath, srcDir, cfg.Context); err != nil {
+		if err := setupContextHooks(s.WorkspacePath, srcDir, cfg.Context, cfg.OnEnd); err != nil {
 			return nil, fmt.Errorf("failed to setup context sync hooks: %w", err)
+		}
+	} else if cfg.OnEnd != "" {
+		if err := setupOnEndHook(s.WorkspacePath, cfg.OnEnd); err != nil {
+			return nil, fmt.Errorf("failed to setup on_end hook: %w", err)
 		}
 	}
 
@@ -252,7 +263,7 @@ export TOC_SESSION_ID=%q
 	return cmd.Process.Release()
 }
 
-func setupContextHooks(workDir, agentDir string, patterns []string) error {
+func setupContextHooks(workDir, agentDir string, patterns []string, onEnd string) error {
 	claudeDir := filepath.Join(workDir, ".claude")
 	if err := os.MkdirAll(claudeDir, 0755); err != nil {
 		return err
@@ -265,11 +276,23 @@ func setupContextHooks(workDir, agentDir string, patterns []string) error {
 		return err
 	}
 
-	// Write settings.json with hook config
+	// Write settings.json with hook config (includes SessionEnd if on_end is set)
 	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings, err := tocsync.HookSettings(scriptPath, onEnd)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(settingsPath, settings, 0644)
+}
 
-	// Merge with existing settings if present
-	settings, err := tocsync.HookSettings(scriptPath)
+func setupOnEndHook(workDir, onEnd string) error {
+	claudeDir := filepath.Join(workDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		return err
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings, err := tocsync.OnEndHookSettings(onEnd)
 	if err != nil {
 		return err
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -171,17 +171,54 @@ func SyncFile(filePath, sessionDir, agentDir string, patterns []string) (bool, e
 	return true, copyFile(filePath, dst)
 }
 
-// HookSettings generates the .claude/settings.json content for the PostToolUse hook.
-func HookSettings(syncScriptPath string) ([]byte, error) {
+// HookSettings generates the .claude/settings.json content for hooks.
+// When onEnd is non-empty, a SessionEnd hook with an agent-type handler is added
+// so that Claude is prompted to persist context before the session closes.
+func HookSettings(syncScriptPath string, onEnd string) ([]byte, error) {
+	hooks := map[string]interface{}{
+		"PostToolUse": []map[string]interface{}{
+			{
+				"matcher": "Edit|Write|MultiEdit",
+				"hooks": []map[string]interface{}{
+					{
+						"type":    "command",
+						"command": syncScriptPath,
+					},
+				},
+			},
+		},
+	}
+
+	if onEnd != "" {
+		hooks["SessionEnd"] = []map[string]interface{}{
+			{
+				"hooks": []map[string]interface{}{
+					{
+						"type":   "agent",
+						"prompt": onEnd,
+					},
+				},
+			},
+		}
+	}
+
+	settings := map[string]interface{}{
+		"hooks": hooks,
+	}
+	return json.MarshalIndent(settings, "", "  ")
+}
+
+// OnEndHookSettings generates a .claude/settings.json with only a SessionEnd hook.
+// Used when context sync patterns are not configured but on_end is.
+func OnEndHookSettings(onEnd string) ([]byte, error) {
 	settings := map[string]interface{}{
 		"hooks": map[string]interface{}{
-			"PostToolUse": []map[string]interface{}{
+			"SessionEnd": []map[string]interface{}{
 				{
-					"matcher": "Edit|Write|MultiEdit",
 					"hooks": []map[string]interface{}{
 						{
-							"type":    "command",
-							"command": syncScriptPath,
+							"type":   "agent",
+							"prompt": onEnd,
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Agents often fail to persist context/memory at the end of a session, even when instructed to in their `agent.md`. This adds a new `on_end` field to agent configs that hooks into Claude Code's `SessionEnd` event to reliably run a user-defined prompt before the session fully closes.

- **New `on_end` field** in `oc-agent.yaml` — accepts a prompt string that describes what to persist and where
- Uses Claude Code's `SessionEnd` hook with `type: "agent"`, giving the prompt full tool access (read/write/edit) before shutdown
- Works independently of `context` sync patterns — can be used standalone or combined with them
- When combined with `context`, files written by the hook are picked up by the existing post-session sync pass

### How it works

When `on_end` is configured, the generated `.claude/settings.json` includes a `SessionEnd` hook alongside any existing `PostToolUse` hooks:

```json
{
  "hooks": {
    "PostToolUse": [ ... ],
    "SessionEnd": [
      {
        "hooks": [
          {
            "type": "agent",
            "prompt": "Save a summary of decisions to context/memory.md..."
          }
        ]
      }
    ]
  }
}
```

### Example config

```yaml
runtime: claude-code
name: my-agent
model: sonnet
context:
  - context/
on_end: >
  Save a summary of decisions and open threads to context/memory.md.
  Append to the file if it exists.
```

## Changes

- `internal/agent/agent.go` — Added `OnEnd` field to `AgentConfig`
- `internal/sync/sync.go` — `HookSettings()` now accepts `onEnd` param and generates `SessionEnd` hook; new `OnEndHookSettings()` for standalone use
- `internal/spawn/spawn.go` — Wires up `on_end` in both `SpawnSession` and `ResumeSession`; new `setupOnEndHook()` for the no-context-patterns case; shows hook status in session info
- `docs/configuration.md` — New "Session end hook" section, updated fields table and example
- `docs/architecture.md` — Added SessionEnd step to lifecycle diagram
- `.claude/skills/toc-dev/SKILL.md` — Updated data structures, spawn flow, and added session end hook section

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Spawn an agent with `on_end` configured and verify the SessionEnd hook fires on exit
- [ ] Spawn an agent with both `context` and `on_end` and verify both hooks are present in settings.json
- [ ] Spawn an agent with only `on_end` (no context patterns) and verify standalone hook setup
- [ ] Resume a session and verify hooks are re-setup correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)