### PR TITLE
Make skill/agent install type-explicit with auto-detection

### DIFF
--- a/cmd/agent_add.go
+++ b/cmd/agent_add.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/audit"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/registry"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func init() {
+	agentCmd.AddCommand(agentAddCmd)
+}
+
+var agentAddCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "Add an agent from the registry",
+	Long:  "Add an agent template from the registry by name. To create from scratch, use: toc agent create",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := config.EnsureInitialized(); err != nil {
+			return err
+		}
+
+		name := args[0]
+
+		ui.Info("Fetching registry...")
+		index, err := registry.FetchIndex()
+		if err != nil {
+			return err
+		}
+
+		entry, found := registry.FindAgent(index, name)
+		if !found {
+			// Check if it exists as a different type to give a better error.
+			if other, ok := registry.Find(index, name); ok {
+				return fmt.Errorf("'%s' is a %s, not an agent — use 'toc skill add %s' instead", name, other.Type, name)
+			}
+			return fmt.Errorf("'%s' not found in the registry — run 'toc registry search' to see what's available", name)
+		}
+
+		ui.Info("Installing agent %s — %s", ui.Bold(entry.Name), ui.Dim(entry.Description))
+
+		if err := registry.Install(entry); err != nil {
+			return err
+		}
+
+		_ = audit.Log("agent.add", map[string]interface{}{
+			"agent":  entry.Name,
+			"source": "registry",
+		})
+
+		fmt.Println()
+		ui.Success("Installed agent %s from registry", ui.Bold(entry.Name))
+		if len(entry.Skills) > 0 {
+			ui.Info("Skills installed: %s", ui.Dim(fmt.Sprintf("%v", entry.Skills)))
+		}
+		ui.Info("Spawn with: %s", ui.Bold(fmt.Sprintf("toc agent spawn %s", entry.Name)))
+		fmt.Println()
+		return nil
+	},
+}

--- a/cmd/registry_install.go
+++ b/cmd/registry_install.go
@@ -56,9 +56,11 @@ var registryInstallCmd = &cobra.Command{
 				ui.Info("Skills installed: %s", ui.Dim(strings.Join(entry.Skills, ", ")))
 			}
 			ui.Info("Spawn with: %s", ui.Bold(fmt.Sprintf("toc agent spawn %s", entry.Name)))
+			ui.Info("Tip: you can also use %s", ui.Bold(fmt.Sprintf("toc agent add %s", entry.Name)))
 		case "skill":
 			ui.Success("Installed skill %s", ui.Bold(entry.Name))
 			ui.Info("Assign to an agent with: %s", ui.Bold("toc agent skills <agent-name>"))
+			ui.Info("Tip: you can also use %s", ui.Bold(fmt.Sprintf("toc skill add %s", entry.Name)))
 		}
 		fmt.Println()
 		return nil

--- a/cmd/skill_add.go
+++ b/cmd/skill_add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tiny-oc/toc/internal/audit"
 	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/registry"
 	"github.com/tiny-oc/toc/internal/skill"
 	"github.com/tiny-oc/toc/internal/ui"
 )
@@ -18,62 +19,102 @@ func init() {
 }
 
 var skillAddCmd = &cobra.Command{
-	Use:   "add <url>",
-	Short: "Add a skill from a public Git repository",
-	Long:  "Add a skill from a Git URL. To install from the registry, use: toc registry install <name>",
+	Use:   "add <url-or-name>",
+	Short: "Add a skill from a Git URL or the registry",
+	Long:  "Add a skill by Git URL or registry name. If the argument is not a URL, the registry is searched automatically.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := config.EnsureInitialized(); err != nil {
 			return err
 		}
 
-		url := args[0]
-		if !skill.IsURL(url) {
-			return fmt.Errorf("expected a URL (https://...)\n\nTo install from the registry: toc registry install %s", url)
+		arg := args[0]
+
+		// If it's not a URL, try the registry.
+		if !skill.IsURL(arg) {
+			return addFromRegistry(arg)
 		}
 
-		ui.Info("Validating skill at %s...", ui.Dim(url))
-
-		tmpDir, err := os.MkdirTemp("", "toc-skill-*")
-		if err != nil {
-			return fmt.Errorf("failed to create temp directory: %w", err)
-		}
-		defer os.RemoveAll(tmpDir)
-
-		gitCmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
-		gitCmd.Stdout = io.Discard
-		gitCmd.Stderr = io.Discard
-		if err := gitCmd.Run(); err != nil {
-			return fmt.Errorf("failed to clone repository — is the URL correct and public?")
-		}
-
-		skillDir, err := skill.FindSkillMDInDir(tmpDir)
-		if err != nil {
-			return err
-		}
-
-		meta, err := skill.ValidateSkillDir(skillDir)
-		if err != nil {
-			return err
-		}
-
-		if skill.Exists(meta.Name) {
-			return fmt.Errorf("a local skill named '%s' already exists — remove it first or use a different name", meta.Name)
-		}
-
-		if err := skill.AddRef(skill.SkillRef{Name: meta.Name, URL: url}); err != nil {
-			return err
-		}
-
-		_ = audit.Log("skill.add", map[string]interface{}{
-			"skill": meta.Name,
-			"url":   url,
-		})
-
-		fmt.Println()
-		ui.Success("Added skill %s from %s", ui.Bold(meta.Name), ui.Dim(url))
-		ui.Info("This skill will be resolved fresh from the URL each time an agent session is spawned.")
-		fmt.Println()
-		return nil
+		return addFromURL(arg)
 	},
+}
+
+func addFromRegistry(name string) error {
+	ui.Info("Fetching registry...")
+	index, err := registry.FetchIndex()
+	if err != nil {
+		return err
+	}
+
+	entry, found := registry.FindSkill(index, name)
+	if !found {
+		// Check if it exists as a different type to give a better error.
+		if other, ok := registry.Find(index, name); ok {
+			return fmt.Errorf("'%s' is an %s, not a skill — use 'toc agent add %s' instead", name, other.Type, name)
+		}
+		return fmt.Errorf("'%s' is not a URL and was not found in the registry\n\nExamples:\n  toc skill add https://github.com/user/skill-repo\n  toc registry search", name)
+	}
+
+	ui.Info("Installing %s — %s", ui.Bold(entry.Name), ui.Dim(entry.Description))
+
+	if err := registry.Install(entry); err != nil {
+		return err
+	}
+
+	_ = audit.Log("skill.add", map[string]interface{}{
+		"skill":  entry.Name,
+		"source": "registry",
+	})
+
+	fmt.Println()
+	ui.Success("Installed skill %s from registry", ui.Bold(entry.Name))
+	ui.Info("Assign to an agent with: %s", ui.Bold("toc agent skills <agent-name>"))
+	fmt.Println()
+	return nil
+}
+
+func addFromURL(url string) error {
+	ui.Info("Validating skill at %s...", ui.Dim(url))
+
+	tmpDir, err := os.MkdirTemp("", "toc-skill-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	gitCmd := exec.Command("git", "clone", "--depth", "1", url, tmpDir)
+	gitCmd.Stdout = io.Discard
+	gitCmd.Stderr = io.Discard
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to clone repository — is the URL correct and public?")
+	}
+
+	skillDir, err := skill.FindSkillMDInDir(tmpDir)
+	if err != nil {
+		return err
+	}
+
+	meta, err := skill.ValidateSkillDir(skillDir)
+	if err != nil {
+		return err
+	}
+
+	if skill.Exists(meta.Name) {
+		return fmt.Errorf("a local skill named '%s' already exists — remove it first or use a different name", meta.Name)
+	}
+
+	if err := skill.AddRef(skill.SkillRef{Name: meta.Name, URL: url}); err != nil {
+		return err
+	}
+
+	_ = audit.Log("skill.add", map[string]interface{}{
+		"skill": meta.Name,
+		"url":   url,
+	})
+
+	fmt.Println()
+	ui.Success("Added skill %s from %s", ui.Bold(meta.Name), ui.Dim(url))
+	ui.Info("This skill will be resolved fresh from the URL each time an agent session is spawned.")
+	fmt.Println()
+	return nil
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -130,10 +130,20 @@ func Find(index *Index, name string) (*Entry, bool) {
 	return nil, false
 }
 
-// FindSkill looks up a skill by exact name (for backward compat with spawn resolution).
+// FindSkill looks up a skill by exact name.
 func FindSkill(index *Index, name string) (*Entry, bool) {
 	for _, e := range index.Entries {
 		if e.Name == name && e.Type == "skill" {
+			return &e, true
+		}
+	}
+	return nil, false
+}
+
+// FindAgent looks up an agent by exact name.
+func FindAgent(index *Index, name string) (*Entry, bool) {
+	for _, e := range index.Entries {
+		if e.Name == name && e.Type == "agent" {
 			return &e, true
 		}
 	}


### PR DESCRIPTION
## Summary

`toc skill add open-source-cto` used to fail with a confusing error asking for a URL or a `--registry` flag. The install experience for registry items was split across two commands (`skill add` for URLs, `registry install` for names) with no clear path for users.

This PR fixes that by making the CLI type-explicit and auto-detecting:

- **`toc skill add <name-or-url>`** — auto-detects whether the argument is a URL or registry name. If it's a name, fetches from the registry (skills only).
- **`toc agent add <name>`** — new command that installs agent templates from the registry (agents only).
- **Type-filtered lookups** — `skill add` uses `FindSkill` and `agent add` uses `FindAgent`, so a skill and agent sharing the same name won't collide.
- **Cross-type error messages** — running `toc skill add <agent-name>` tells the user to use `toc agent add` instead, and vice versa.
- **`toc registry install`** still works as a convenience catch-all but now hints at the type-specific commands.

### Before
```
$ toc skill add open-source-cto
Error: expected a URL (https://...) or use --registry flag to install by name
```

### After
```
$ toc skill add open-source-cto
  → Fetching registry...
  → Installing open-source-cto — Technical decision-making and code quality standards
  ✓ Installed skill open-source-cto from registry

$ toc agent add some-agent
  → Fetching registry...
  → Installing agent some-agent — ...
  ✓ Installed agent some-agent from registry
```

## Test plan
- [ ] `toc skill add <registry-skill-name>` installs the skill
- [ ] `toc skill add <url>` still works for URL-based skills
- [ ] `toc agent add <registry-agent-name>` installs the agent and its skills
- [ ] `toc skill add <agent-name>` shows helpful error pointing to `agent add`
- [ ] `toc agent add <skill-name>` shows helpful error pointing to `skill add`
- [ ] `toc registry install` still works for both types
- [ ] `toc skill add <nonexistent>` shows clear error with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)