### PR TITLE
Show token usage per session in status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tiny-oc/toc/internal/session"
 	"github.com/tiny-oc/toc/internal/skill"
 	"github.com/tiny-oc/toc/internal/ui"
+	"github.com/tiny-oc/toc/internal/usage"
 )
 
 func init() {
@@ -110,7 +111,13 @@ var statusCmd = &cobra.Command{
 				case "stale":
 					badge = ui.Yellow("◌ stale")
 				}
-				fmt.Printf("    %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
+				tokens := usage.ForSession(s.WorkspacePath, s.ID)
+				tokenStr := tokens.FormatTotal()
+				if tokenStr != "" {
+					fmt.Printf("    %s  %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]), ui.Dim(tokenStr))
+				} else {
+					fmt.Printf("    %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
+				}
 			}
 		}
 		fmt.Println()

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -1,0 +1,109 @@
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TokenUsage holds aggregated token counts for a session.
+type TokenUsage struct {
+	InputTokens  int64
+	OutputTokens int64
+	CacheRead    int64
+	CacheCreate  int64
+}
+
+// Total returns the sum of all token fields.
+func (u TokenUsage) Total() int64 {
+	return u.InputTokens + u.OutputTokens + u.CacheRead + u.CacheCreate
+}
+
+// FormatTotal returns a human-readable token count.
+func (u TokenUsage) FormatTotal() string {
+	t := u.Total()
+	if t == 0 {
+		return ""
+	}
+	if t >= 1_000_000 {
+		return fmt.Sprintf("%.1fM tokens", float64(t)/1_000_000)
+	}
+	if t >= 1_000 {
+		return fmt.Sprintf("%.1fk tokens", float64(t)/1_000)
+	}
+	return fmt.Sprintf("%d tokens", t)
+}
+
+// ForSession reads Claude Code's local session data and sums up token usage.
+// workspacePath is the session's working directory (e.g. /tmp/toc-sessions/agent-123).
+// sessionID is the Claude session UUID.
+func ForSession(workspacePath, sessionID string) TokenUsage {
+	projectDir := claudeProjectDir(workspacePath)
+	if projectDir == "" {
+		return TokenUsage{}
+	}
+
+	jsonlPath := filepath.Join(projectDir, sessionID+".jsonl")
+	return parseJSONL(jsonlPath)
+}
+
+// claudeProjectDir derives the ~/.claude/projects/<encoded-path>/ directory
+// for a given workspace path.
+func claudeProjectDir(workspacePath string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	// On macOS, /tmp is a symlink to /private/tmp
+	resolved, err := filepath.EvalSymlinks(workspacePath)
+	if err != nil {
+		resolved = workspacePath
+	}
+
+	// Claude Code encodes paths by replacing "/" with "-" and removing "."
+	encoded := strings.ReplaceAll(resolved, "/", "-")
+
+	return filepath.Join(home, ".claude", "projects", encoded)
+}
+
+type jsonlMessage struct {
+	Message *struct {
+		Usage *struct {
+			InputTokens             int64 `json:"input_tokens"`
+			OutputTokens            int64 `json:"output_tokens"`
+			CacheReadInputTokens    int64 `json:"cache_read_input_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func parseJSONL(path string) TokenUsage {
+	f, err := os.Open(path)
+	if err != nil {
+		return TokenUsage{}
+	}
+	defer f.Close()
+
+	var usage TokenUsage
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		var msg jsonlMessage
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			continue
+		}
+		if msg.Message != nil && msg.Message.Usage != nil {
+			u := msg.Message.Usage
+			usage.InputTokens += u.InputTokens
+			usage.OutputTokens += u.OutputTokens
+			usage.CacheRead += u.CacheReadInputTokens
+			usage.CacheCreate += u.CacheCreationInputTokens
+		}
+	}
+	return usage
+}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,0 +1,72 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	content := `{"type":"user","message":{"role":"user","content":"hello"}}
+{"type":"assistant","message":{"role":"assistant","content":"hi","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":200,"cache_creation_input_tokens":300}}}
+{"type":"assistant","message":{"role":"assistant","content":"more","usage":{"input_tokens":150,"output_tokens":75,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	u := parseJSONL(path)
+
+	if u.InputTokens != 250 {
+		t.Errorf("InputTokens = %d, want 250", u.InputTokens)
+	}
+	if u.OutputTokens != 125 {
+		t.Errorf("OutputTokens = %d, want 125", u.OutputTokens)
+	}
+	if u.CacheRead != 200 {
+		t.Errorf("CacheRead = %d, want 200", u.CacheRead)
+	}
+	if u.CacheCreate != 300 {
+		t.Errorf("CacheCreate = %d, want 300", u.CacheCreate)
+	}
+	if u.Total() != 875 {
+		t.Errorf("Total = %d, want 875", u.Total())
+	}
+}
+
+func TestFormatTotal(t *testing.T) {
+	tests := []struct {
+		usage TokenUsage
+		want  string
+	}{
+		{TokenUsage{}, ""},
+		{TokenUsage{InputTokens: 500}, "500 tokens"},
+		{TokenUsage{InputTokens: 1500}, "1.5k tokens"},
+		{TokenUsage{InputTokens: 1_500_000}, "1.5M tokens"},
+	}
+	for _, tt := range tests {
+		got := tt.usage.FormatTotal()
+		if got != tt.want {
+			t.Errorf("FormatTotal() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestParseJSONL_MissingFile(t *testing.T) {
+	u := parseJSONL("/nonexistent/file.jsonl")
+	if u.Total() != 0 {
+		t.Errorf("expected zero usage for missing file, got %d", u.Total())
+	}
+}
+
+func TestClaudeProjectDir(t *testing.T) {
+	dir := claudeProjectDir("/private/tmp/toc-sessions/buddy-123")
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".claude", "projects", "-private-tmp-toc-sessions-buddy-123")
+	if dir != want {
+		t.Errorf("claudeProjectDir = %q, want %q", dir, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/usage` package that reads Claude Code's local JSONL session files (`~/.claude/projects/`) to aggregate token counts per session
- Updates `toc status` to display token usage (e.g. `234.5k tokens`) next to each recent session
- Gracefully shows nothing when session data is unavailable (stale/deleted sessions)

## Test plan
- [x] Unit tests for JSONL parsing, formatting, missing files, and path encoding
- [ ] Run `toc status` in a workspace with existing sessions and verify token counts appear
- [ ] Verify sessions without Claude data (stale) still display correctly without tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)