### PR TITLE
Add git backing to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ When you run `toc agent spawn`, it:
 - [x] Sub-agents — agents that spawn and coordinate other agents
 - [ ] Session sandbox — unforgeable identity and permissions ([#12](https://github.com/louismorgner/tiny-oc/issues/12))
 - [ ] Cost controls — per-agent and per-session spending limits
+- [ ] Git backing for `.toc/` and agent sync
 - [ ] Integrations and permissions — connect agents to external tools with scoped access
 - [ ] **v1 release**
 


### PR DESCRIPTION
## Summary
- Adds "Git backing for `.toc/` and agent sync" to the roadmap in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)