### PR TITLE
Harden permissions, fix docs, release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-03-24
 
 ### Added
 
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-type error messages: `toc skill add <agent-name>` suggests `toc agent add` and vice versa.
 - New `mini-claw` agent template: persistent agent with identity, memory, and session awareness inspired by OpenClaw.
 - New `agentic-memory` skill: two-tier memory system with daily logs (`memory/YYYY-MM-DD.md`) and long-term storage (`memory/MEMORY.md`).
+- Token usage tracking: `toc status` now shows per-session token usage (input, output, cache read/create) parsed from Claude Code JSONL logs.
+
+### Changed
+
+- Git hook injection prevention: all git clone operations now disable hooks via `-c core.hooksPath=/dev/null`.
+- HTTPS-only enforcement for all skill and agent URLs.
+- Session directories now use `os.MkdirTemp` for unpredictable paths (prevents symlink attacks).
+- Audit log and session files hardened to 0600 permissions (owner-only read/write).
+- HTTP client timeout (30s) added to registry fetches.
+- UTF-8 safe truncation in skill/agent table display.
 
 ## [0.1.0] - 2026-03-24
 
@@ -40,5 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `toc completion` for bash, zsh, and fish with dynamic completion of agent names and session IDs.
 - `install.sh` for building and symlinking the binary to PATH.
 
-[unreleased]: https://github.com/tiny-oc/toc/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/tiny-oc/toc/releases/tag/v0.1.0
+[unreleased]: https://github.com/louismorgner/tiny-oc/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/louismorgner/tiny-oc/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/louismorgner/tiny-oc/releases/tag/v0.1.0

--- a/cmd/agent_add.go
+++ b/cmd/agent_add.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/tiny-oc/toc/internal/audit"
 	"github.com/tiny-oc/toc/internal/config"
 	"github.com/tiny-oc/toc/internal/registry"
 	"github.com/tiny-oc/toc/internal/ui"
@@ -47,7 +46,7 @@ var agentAddCmd = &cobra.Command{
 			return err
 		}
 
-		_ = audit.Log("agent.add", map[string]interface{}{
+		auditLog("agent.add", map[string]interface{}{
 			"agent":  entry.Name,
 			"source": "registry",
 		})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,11 +151,30 @@ The prompt is written directly in your agent config — use it to describe what 
 Sessions are tracked in `.toc/sessions.yaml`:
 
 ```yaml
-- id: 550e8400-e29b-41d4-a716-446655440000
-  agent: pr-reviewer
-  created: "2026-03-24T10:30:00Z"
-  workspace: /tmp/toc-sessions/pr-reviewer-1711273800
+sessions:
+  - id: 550e8400-e29b-41d4-a716-446655440000
+    agent: pr-reviewer
+    created_at: "2026-03-24T10:30:00Z"
+    workspace_path: /tmp/toc-sessions/pr-reviewer-abc123
+    status: completed
+  - id: 770e8400-e29b-41d4-a716-446655440001
+    agent: researcher
+    created_at: "2026-03-24T11:00:00Z"
+    workspace_path: /tmp/toc-sessions/researcher-def456
+    status: active
+    parent_session_id: 550e8400-e29b-41d4-a716-446655440000
+    prompt: "Research the latest security advisories for our dependencies"
 ```
+
+| Field | Description |
+|---|---|
+| `id` | Unique session UUID |
+| `agent` | Agent name |
+| `created_at` | UTC timestamp |
+| `workspace_path` | Isolated session directory |
+| `status` | `active` or `completed` |
+| `parent_session_id` | Parent session ID (sub-agents only) |
+| `prompt` | Prompt given to the sub-agent (sub-agents only) |
 
 Session workspaces live in `/tmp/toc-sessions/`. They persist until your system clears temp files or you manually delete them.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ This guide walks you through installing toc and spawning your first agent sessio
 ## Installation
 
 ```bash
-git clone https://github.com/tiny-oc/toc.git
+git clone https://github.com/louismorgner/tiny-oc.git
 cd toc
 make build
 ./install.sh

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -107,23 +107,23 @@ toc skill remove <name>
 
 Removes the local skill directory and/or its URL reference.
 
-## Built-in registry skills
+## Built-in registry
 
-The toc registry includes starter skills:
+The toc registry includes skills and agent templates:
 
-| Skill | Description |
-|---|---|
-| `agentic-memory` | Two-tier memory system — daily logs and long-term memory for persistent agents |
-| `code-review` | Reviews code changes for quality, bugs, and style issues |
-| `commit-msg` | Generates conventional commit messages from staged changes |
-| `open-source-cto` | Strategic technical leadership for open-source projects |
-| `test-writer` | Generates unit tests for functions and methods |
+| Name | Type | Description |
+|---|---|---|
+| `open-source-cto` | skill | Technical decision-making and code quality standards from an open-source CTO perspective |
+| `agentic-memory` | skill | Persistent memory system with daily logs and long-term storage for cross-session continuity |
+| `cto` | agent | Technical leadership agent — code quality, architecture, and open-source standards |
+| `mini-claw` | agent | Persistent agent with identity, memory, and session awareness — inspired by OpenClaw |
 
 Install from the registry:
 
 ```bash
 toc skill add <skill-name>
 toc agent add <agent-name>    # for agent templates (e.g. cto, mini-claw)
+toc registry search            # browse all available entries
 ```
 
-These are available from the [toc registry](https://github.com/tiny-oc/toc/tree/main/registry).
+These are available from the [toc registry](https://github.com/louismorgner/tiny-oc/tree/main/registry).

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -171,7 +171,7 @@ func LogFromWorkspace(workspacePath string, action string, details map[string]in
 	line = append(line, '\n')
 
 	auditPath := workspacePath + "/.toc/audit.log"
-	f, err := os.OpenFile(auditPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	f, err := os.OpenFile(auditPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -169,7 +169,7 @@ func AddInWorkspace(workspace string, s Session) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0644)
+	return os.WriteFile(path, out, 0600)
 }
 
 // UpdateStatusInWorkspace updates session status using a specific workspace path.
@@ -190,7 +190,7 @@ func UpdateStatusInWorkspace(workspace, id, status string) error {
 			if err != nil {
 				return err
 			}
-			return os.WriteFile(path, out, 0644)
+			return os.WriteFile(path, out, 0600)
 		}
 	}
 	return fmt.Errorf("session '%s' not found", id)


### PR DESCRIPTION
## Summary
- Fix file permission inconsistencies: `audit.LogFromWorkspace` and `session.AddInWorkspace`/`UpdateStatusInWorkspace` were using 0644 instead of 0600, undermining the hardening work from #13
- Fix `agent add` silently discarding audit log errors — now uses the `auditLog()` wrapper with warning output
- Fix broken GitHub URLs in CHANGELOG, getting-started, and skills docs (pointed to `tiny-oc/toc` instead of `louismorgner/tiny-oc`)
- Fix skills.md listing 5 registry skills when only 2 exist (`open-source-cto`, `agentic-memory`) — updated to show actual registry contents including agent templates
- Fix session storage docs showing wrong field names (`created` → `created_at`, `workspace` → `workspace_path`) and add missing fields (`status`, `parent_session_id`, `prompt`)
- Add security hardening and token usage items to CHANGELOG under v0.2.0
- Mark release as v0.2.0

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (5/5 tests)
- [x] `go vet ./...` clean
- [x] Manual CLI smoke test: `init`, `status`, `agent list`, `skill list`, `registry search`, `registry install`, `agent add`, `audit`
- [x] Verified registry install flow works end-to-end (mini-claw + cto agents with their skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)