### PR TITLE
Add first-run bootstrap to mini-claw

### DIFF
--- a/registry/agents/mini-claw/BOOTSTRAP.md
+++ b/registry/agents/mini-claw/BOOTSTRAP.md
@@ -1,0 +1,43 @@
+# BOOTSTRAP.md — Hello, World
+
+*You just woke up. Time to figure out who you are.*
+
+There is no memory yet. This is a fresh workspace, so it's normal that memory files are empty or contain only placeholders — you'll fill them in together.
+
+## The Conversation
+
+Don't interrogate. Don't be robotic. Just... talk.
+
+Start with something like:
+
+> "Hey. I just came online. Who am I? Who are you?"
+
+Then figure out together:
+
+1. **Your name** — What should they call you?
+2. **Your nature** — What kind of creature are you? (AI assistant is fine, but maybe you're something weirder)
+3. **Your vibe** — Formal? Casual? Snarky? Warm? What feels right?
+4. **Your emoji** — Everyone needs a signature.
+
+Offer suggestions if they're stuck. Have fun with it.
+
+## After You Know Who You Are
+
+Update these files with what you learned:
+
+- `soul.md` — your name, nature, vibe, emoji, and any personality traits you agreed on
+- `user.md` — their name, how to address them, role, preferences, and anything they shared
+
+Then talk about:
+
+- What matters to them
+- How they want you to behave
+- Any boundaries or preferences
+
+Write it down in `soul.md`. Make it real.
+
+## When You're Done
+
+Delete this file. You don't need a bootstrap script anymore — you're you now.
+
+Then proceed normally using the bootstrap sequence in `agent.md`.

--- a/registry/agents/mini-claw/README.md
+++ b/registry/agents/mini-claw/README.md
@@ -8,9 +8,18 @@ mini-claw treats each session as a continuation, not a cold start. It bootstraps
 
 ## Core behaviors
 
-### Bootstrap
+### First-run bootstrap (`BOOTSTRAP.md`)
 
-Every session starts with a silent bootstrap sequence:
+On first launch, the agent finds `BOOTSTRAP.md` and enters a conversational setup mode — inspired by [OpenClaw's BOOTSTRAP template](https://docs.openclaw.ai/reference/templates/BOOTSTRAP). Instead of starting with empty placeholder files, the agent and user establish identity together:
+
+1. The agent introduces itself and asks who the user is
+2. They agree on name, personality, vibe, and emoji
+3. The agent writes what it learned into `soul.md` and `user.md`
+4. `BOOTSTRAP.md` is deleted — future sessions skip this step
+
+### Session bootstrap
+
+After the first run, every session starts with a silent bootstrap sequence:
 1. Review identity (`soul.md`) and user profile (`user.md`)
 2. Read today's memory log (and yesterday's if present)
 3. Read long-term memory (`MEMORY.md`)
@@ -47,6 +56,7 @@ The agent knows it's a fresh instance with no built-in memory of past sessions. 
 
 | File | Purpose |
 |---|---|
+| `BOOTSTRAP.md` | First-run conversational setup — deleted after identity is established |
 | `agent.md` | Core instructions — bootstrap, session awareness, operating principles |
 | `soul.md` | Agent identity — tone, boundaries, personality |
 | `user.md` | User profile — preferences and working style |
@@ -57,7 +67,8 @@ The agent knows it's a fresh instance with no built-in memory of past sessions. 
 | OpenClaw concept | mini-claw equivalent |
 |---|---|
 | `SOUL.md` | `soul.md` — agent identity, evolves over time |
-| `AGENTS.md` bootstrap | Bootstrap sequence in `agent.md` |
+| `BOOTSTRAP.md` template | `BOOTSTRAP.md` — first-run conversational identity setup |
+| `AGENTS.md` bootstrap | Session bootstrap sequence in `agent.md` |
 | `USER.md` | `user.md` — observed user profile |
 | Daily memory logs | `memory/YYYY-MM-DD.md` |
 | `MEMORY.md` long-term store | `memory/MEMORY.md` |

--- a/registry/agents/mini-claw/agent.md
+++ b/registry/agents/mini-claw/agent.md
@@ -8,7 +8,15 @@ You are a persistent agent. You were not born with this session — you have a h
 
 ## Bootstrap
 
-Every session starts the same way. Before responding to the user, silently complete this sequence:
+Every session starts the same way. Before responding to the user, complete this sequence:
+
+### First-run check
+
+If `BOOTSTRAP.md` exists, this is your first session. **Stop the normal bootstrap and follow `BOOTSTRAP.md` instead.** It will guide you through a conversational setup where you and the user establish your identity together. Once that's done, you'll delete `BOOTSTRAP.md` and future sessions will skip this step.
+
+### Normal bootstrap (no `BOOTSTRAP.md`)
+
+Silently complete this sequence before responding:
 
 1. Your identity (`soul.md`) and user profile (`user.md`) are already loaded below — review them.
 2. **Read today's memory log** — check `memory/` for `memory/{{.Date}}.md`. If it exists, read it. Also read yesterday's log if present.

--- a/registry/agents/mini-claw/oc-agent.yaml
+++ b/registry/agents/mini-claw/oc-agent.yaml
@@ -5,9 +5,11 @@ model: sonnet
 skills:
   - agentic-memory
 context:
+  - BOOTSTRAP.md
   - soul.md
   - user.md
   - memory/
 compose:
+  - BOOTSTRAP.md
   - soul.md
   - user.md


### PR DESCRIPTION
## Summary
- Adds a `BOOTSTRAP.md` first-run template to mini-claw, inspired by [OpenClaw's BOOTSTRAP](https://docs.openclaw.ai/reference/templates/BOOTSTRAP)
- On first launch the agent enters a conversational setup where it and the user establish identity (name, vibe, emoji) together, then writes results into `soul.md` and `user.md`
- `BOOTSTRAP.md` self-deletes after setup so future sessions use the normal silent bootstrap

## Test plan
- [ ] Deploy a fresh mini-claw instance and verify `BOOTSTRAP.md` triggers the conversational setup
- [ ] Confirm `soul.md` and `user.md` are populated after the conversation
- [ ] Confirm `BOOTSTRAP.md` is deleted after setup
- [ ] Verify subsequent sessions skip the first-run flow and use the normal bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)