### PR TITLE
Add `toc update` command for CLI self-update

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,19 +1,27 @@
 package cmd
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/tiny-oc/toc/internal/ui"
 )
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
@@ -26,6 +34,13 @@ var updateCmd = &cobra.Command{
 		fmt.Println()
 
 		current := version
+
+		if current == "dev" {
+			ui.Warn("Running a dev build — skipping update check")
+			fmt.Println()
+			return nil
+		}
+
 		ui.Info("Current version: %s", ui.Bold(current))
 
 		// Fetch latest release from GitHub
@@ -48,7 +63,7 @@ var updateCmd = &cobra.Command{
 		goarch := runtime.GOARCH
 
 		archive := fmt.Sprintf("toc_%s_%s_%s.tar.gz", latest, goos, goarch)
-		url := fmt.Sprintf("https://github.com/louismorgner/tiny-oc/releases/download/v%s/%s", latest, archive)
+		baseURL := fmt.Sprintf("https://github.com/louismorgner/tiny-oc/releases/download/v%s", latest)
 
 		ui.Info("Downloading %s...", archive)
 
@@ -60,17 +75,28 @@ var updateCmd = &cobra.Command{
 		defer os.RemoveAll(tmpDir)
 
 		archivePath := filepath.Join(tmpDir, archive)
-		if err := downloadFile(url, archivePath); err != nil {
+		if err := downloadFile(baseURL+"/"+archive, archivePath); err != nil {
 			return fmt.Errorf("failed to download update: %w", err)
 		}
 
+		// Download and verify checksum
+		checksumURL := baseURL + "/checksums.txt"
+		checksumPath := filepath.Join(tmpDir, "checksums.txt")
+		if err := downloadFile(checksumURL, checksumPath); err != nil {
+			return fmt.Errorf("failed to download checksums: %w", err)
+		}
+
+		if err := verifyChecksum(archivePath, checksumPath, archive); err != nil {
+			return fmt.Errorf("checksum verification failed: %w", err)
+		}
+		ui.Success("Checksum verified")
+
 		// Extract
-		extractCmd := exec.Command("tar", "-xzf", archivePath, "-C", tmpDir)
-		if err := extractCmd.Run(); err != nil {
+		newBinary := filepath.Join(tmpDir, "toc")
+		if err := extractTarGz(archivePath, "toc", newBinary); err != nil {
 			return fmt.Errorf("failed to extract archive: %w", err)
 		}
 
-		newBinary := filepath.Join(tmpDir, "toc")
 		if err := os.Chmod(newBinary, 0755); err != nil {
 			return fmt.Errorf("failed to set permissions: %w", err)
 		}
@@ -101,7 +127,7 @@ type githubRelease struct {
 }
 
 func fetchLatestVersion() (string, error) {
-	resp, err := http.Get("https://api.github.com/repos/louismorgner/tiny-oc/releases/latest")
+	resp, err := httpClient.Get("https://api.github.com/repos/louismorgner/tiny-oc/releases/latest")
 	if err != nil {
 		return "", err
 	}
@@ -120,7 +146,7 @@ func fetchLatestVersion() (string, error) {
 }
 
 func downloadFile(url, dest string) error {
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return err
 	}
@@ -140,12 +166,100 @@ func downloadFile(url, dest string) error {
 	return err
 }
 
-func replaceBinary(src, dst string) error {
-	// Atomic-ish replacement: rename new over old.
-	// On Unix, we can rename over a running binary.
-	input, err := os.ReadFile(src)
+func verifyChecksum(archivePath, checksumPath, archiveName string) error {
+	// Compute SHA256 of the downloaded archive
+	f, err := os.Open(archivePath)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dst, input, 0755)
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+
+	// Parse checksums.txt for the expected hash
+	data, err := os.ReadFile(checksumPath)
+	if err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == archiveName {
+			if parts[0] != actual {
+				return fmt.Errorf("expected %s, got %s", parts[0], actual)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no checksum found for %s", archiveName)
+}
+
+func extractTarGz(archivePath, targetName, destPath string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Name == targetName {
+			out, err := os.Create(destPath)
+			if err != nil {
+				return err
+			}
+			defer out.Close()
+			_, err = io.Copy(out, tr)
+			return err
+		}
+	}
+	return fmt.Errorf("%s not found in archive", targetName)
+}
+
+func replaceBinary(src, dst string) error {
+	// Try atomic rename first (works on same filesystem)
+	err := os.Rename(src, dst)
+	if err == nil {
+		return nil
+	}
+	// Fall back to copy-to-tmpfile-then-rename for cross-device moves
+	if !errors.Is(err, syscall.EXDEV) {
+		return err
+	}
+	tmpDst := dst + ".tmp"
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(tmpDst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmpDst)
+		return err
+	}
+	out.Close()
+	return os.Rename(tmpDst, dst)
 }


### PR DESCRIPTION
## Summary
- Adds a `toc update` command that checks the latest GitHub release, compares it to the current version, and downloads + replaces the binary in-place
- Uses `runtime.GOOS`/`runtime.GOARCH` to pick the correct platform archive, matching the existing GoReleaser naming conventions
- Handles the "already up to date" case gracefully

## Test plan
- [ ] Run `toc update` when already on latest version — should print "Already up to date!"
- [ ] Run `toc update` on an older version — should download and replace the binary
- [ ] Verify `toc --version` shows the new version after updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)