### PR TITLE
Fix status command to sort sessions by most recent first

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -120,9 +121,13 @@ var statusCmd = &cobra.Command{
 		if len(sf.Sessions) == 0 {
 			fmt.Printf("  %s\n", ui.Dim("none"))
 		} else {
-			shown := sf.Sessions
+			shown := make([]session.Session, len(sf.Sessions))
+			copy(shown, sf.Sessions)
+			sort.Slice(shown, func(i, j int) bool {
+				return shown[i].CreatedAt.After(shown[j].CreatedAt)
+			})
 			if len(shown) > 5 {
-				shown = shown[len(shown)-5:]
+				shown = shown[:5]
 			}
 			fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d total)", len(sf.Sessions))))
 			for _, s := range shown {


### PR DESCRIPTION
## Summary
- Sort sessions by `created_at` descending in `toc status` so the most recent sessions appear at the top
- Previously, display order depended on insertion order in `sessions.yaml`, which wasn't guaranteed to be chronological
- Uses a copy of the slice to avoid mutating the original session data

Closes #40

## Test plan
- [ ] Run `toc status` with multiple sessions created at different times and verify newest appears first
- [ ] Verify that sessions with identical timestamps don't cause issues
- [ ] Confirm only the display is affected — `sessions.yaml` file order is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)