### PR TITLE
Add sub-agent resume capability

### DIFF
--- a/cmd/runtime_spawn.go
+++ b/cmd/runtime_spawn.go
@@ -6,15 +6,17 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tiny-oc/toc/internal/audit"
 	"github.com/tiny-oc/toc/internal/runtime"
+	"github.com/tiny-oc/toc/internal/session"
 	"github.com/tiny-oc/toc/internal/spawn"
 	"github.com/tiny-oc/toc/internal/ui"
 )
 
 var runtimeSpawnPrompt string
+var runtimeSpawnResume string
 
 func init() {
-	runtimeSpawnCmd.Flags().StringVarP(&runtimeSpawnPrompt, "prompt", "p", "", "Task prompt for the sub-agent (required)")
-	runtimeSpawnCmd.MarkFlagRequired("prompt")
+	runtimeSpawnCmd.Flags().StringVarP(&runtimeSpawnPrompt, "prompt", "p", "", "Task prompt for the sub-agent")
+	runtimeSpawnCmd.Flags().StringVar(&runtimeSpawnResume, "resume", "", "Resume a previous sub-agent session by ID")
 	runtimeCmd.AddCommand(runtimeSpawnCmd)
 }
 
@@ -22,6 +24,13 @@ var runtimeSpawnCmd = &cobra.Command{
 	Use:   "spawn <agent-name>",
 	Short: "Spawn a sub-agent session in the background",
 	Args:  cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --prompt is required unless --resume is set
+		if runtimeSpawnResume == "" && runtimeSpawnPrompt == "" {
+			return fmt.Errorf("required flag \"prompt\" not set (use --prompt or --resume)")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, err := runtime.FromEnv()
 		if err != nil {
@@ -40,7 +49,12 @@ var runtimeSpawnCmd = &cobra.Command{
 			return fmt.Errorf("agent '%s' is not allowed to spawn '%s' — check sub-agents config in oc-agent.yaml", ctx.Agent, targetName)
 		}
 
-		// Load target agent
+		// Resume flow
+		if runtimeSpawnResume != "" {
+			return resumeSubAgent(ctx, targetName, runtimeSpawnResume, runtimeSpawnPrompt)
+		}
+
+		// Normal spawn flow
 		targetCfg, err := ctx.LoadTargetAgent(targetName)
 		if err != nil {
 			return fmt.Errorf("agent '%s' not found in workspace", targetName)
@@ -73,4 +87,46 @@ var runtimeSpawnCmd = &cobra.Command{
 		fmt.Println()
 		return nil
 	},
+}
+
+func resumeSubAgent(ctx *runtime.Context, targetName, resumeID, prompt string) error {
+	s, err := session.FindByIDPrefixInWorkspace(ctx.Workspace, resumeID)
+	if err != nil {
+		return fmt.Errorf("failed to find session to resume: %w", err)
+	}
+
+	if s.Agent != targetName {
+		return fmt.Errorf("session '%s' belongs to agent '%s', not '%s'", s.ID, s.Agent, targetName)
+	}
+
+	if s.ParentSessionID != ctx.SessionID {
+		return fmt.Errorf("session '%s' is not a sub-agent of this session", s.ID)
+	}
+
+	ui.Info("Resuming sub-agent %s (session %s)...", ui.Bold(targetName), ui.Cyan(s.ID[:8]))
+
+	result, err := spawn.ResumeSubSession(s, spawn.SubResumeOpts{
+		ParentSessionID: ctx.SessionID,
+		Prompt:          prompt,
+		WorkspaceDir:    ctx.Workspace,
+	})
+	if err != nil {
+		return err
+	}
+
+	_ = audit.LogFromWorkspace(ctx.Workspace, "runtime.resume", map[string]interface{}{
+		"parent_agent":   ctx.Agent,
+		"parent_session": ctx.SessionID,
+		"target_agent":   targetName,
+		"session_id":     result.SessionID,
+		"prompt":         prompt,
+	})
+
+	fmt.Println()
+	ui.Success("Sub-agent %s resumed", ui.Bold(targetName))
+	ui.Info("Session ID: %s", ui.Cyan(result.SessionID))
+	ui.Info("Check status: %s", ui.Bold(fmt.Sprintf("toc runtime status %s", result.SessionID)))
+	ui.Info("Read output:  %s", ui.Bold(fmt.Sprintf("toc runtime output %s", result.SessionID)))
+	fmt.Println()
+	return nil
 }

--- a/cmd/runtime_status.go
+++ b/cmd/runtime_status.go
@@ -103,15 +103,7 @@ func showSubAgentStatus(ctx *runtime.Context, sessionID string) error {
 	}
 
 	status := s.ResolvedStatus()
-	var badge string
-	switch status {
-	case "active":
-		badge = ui.Green("● active")
-	case "completed":
-		badge = ui.Green("● completed")
-	case "stale":
-		badge = ui.Yellow("◌ stale")
-	}
+	badge := statusBadge(status)
 
 	fmt.Println()
 	fmt.Printf("  %s %s\n", ui.Bold("Agent:"), ui.Cyan(s.Agent))
@@ -128,6 +120,10 @@ func showSubAgentStatus(ctx *runtime.Context, sessionID string) error {
 
 	if status == "completed" {
 		ui.Info("Read output: %s", ui.Bold(fmt.Sprintf("toc runtime output %s", sessionID)))
+		fmt.Println()
+	}
+	if status == "failed" {
+		ui.Info("Resume with: %s", ui.Bold(fmt.Sprintf("toc runtime spawn %s --resume %s", s.Agent, sessionID)))
 		fmt.Println()
 	}
 
@@ -151,15 +147,7 @@ func listSubAgentStatuses(ctx *runtime.Context) error {
 
 	for _, s := range children {
 		status := s.ResolvedStatus()
-		var badge string
-		switch status {
-		case "active":
-			badge = ui.Green("● active")
-		case "completed":
-			badge = ui.Green("● completed")
-		case "stale":
-			badge = ui.Yellow("◌ stale")
-		}
+		badge := statusBadge(status)
 
 		prompt := s.Prompt
 		if len(prompt) > 40 {
@@ -171,4 +159,19 @@ func listSubAgentStatuses(ctx *runtime.Context) error {
 
 	fmt.Println()
 	return nil
+}
+
+func statusBadge(status string) string {
+	switch status {
+	case "active":
+		return ui.Green("● active")
+	case "completed":
+		return ui.Green("● completed")
+	case "failed":
+		return ui.Red("✗ failed")
+	case "stale":
+		return ui.Yellow("◌ stale")
+	default:
+		return ui.Dim(status)
+	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -199,6 +199,19 @@ func Load(name string) (*AgentConfig, error) {
 	return &cfg, nil
 }
 
+// LoadFrom loads an agent config from a specific directory path.
+func LoadFrom(dir string) (*AgentConfig, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "oc-agent.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("agent config not found in %s: %w", dir, err)
+	}
+	var cfg AgentConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse agent config: %w", err)
+	}
+	return &cfg, nil
+}
+
 func Save(cfg *AgentConfig) error {
 	data, err := yaml.Marshal(cfg)
 	if err != nil {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/tiny-oc/toc/internal/config"
@@ -13,6 +14,7 @@ import (
 const (
 	StatusActive    = "active"
 	StatusCompleted = "completed"
+	StatusFailed    = "failed"
 )
 
 type Session struct {
@@ -28,6 +30,7 @@ type Session struct {
 // ResolvedStatus returns the display status, checking workspace existence.
 // For sub-agent sessions (ParentSessionID set), it also checks for toc-output.txt
 // as a completion signal since the background process can't update sessions.yaml.
+// If toc-exit-code.txt contains a non-zero exit code, the session is "failed".
 func (s *Session) ResolvedStatus() string {
 	if _, err := os.Stat(s.WorkspacePath); os.IsNotExist(err) {
 		return "stale"
@@ -35,8 +38,17 @@ func (s *Session) ResolvedStatus() string {
 	if s.Status == StatusActive && s.ParentSessionID != "" {
 		// Sub-agent: check if output file exists (means claude --print finished)
 		if _, err := os.Stat(filepath.Join(s.WorkspacePath, "toc-output.txt")); err == nil {
+			// Check exit code to distinguish completed from failed
+			if exitCode, err := os.ReadFile(filepath.Join(s.WorkspacePath, "toc-exit-code.txt")); err == nil {
+				if strings.TrimSpace(string(exitCode)) != "0" {
+					return "failed"
+				}
+			}
 			return "completed"
 		}
+	}
+	if s.Status == StatusFailed {
+		return "failed"
 	}
 	if s.Status == StatusActive {
 		return "active"

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -230,6 +230,61 @@ func SpawnSubSession(cfg *agent.AgentConfig, opts SubSpawnOpts) (*SpawnResult, e
 	return &SpawnResult{SessionID: sessionID, FailedSkills: failedSkills}, nil
 }
 
+// SubResumeOpts contains options for resuming a sub-agent session.
+type SubResumeOpts struct {
+	ParentSessionID string
+	Prompt          string // optional additional context for the resumed session
+	WorkspaceDir    string
+}
+
+// ResumeSubSession resumes a failed or completed sub-agent session.
+// The resumed session reuses the existing session directory and conversation history.
+func ResumeSubSession(s *session.Session, opts SubResumeOpts) (*SpawnResult, error) {
+	if _, err := os.Stat(s.WorkspacePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("session workspace no longer exists: %s", s.WorkspacePath)
+	}
+
+	status := s.ResolvedStatus()
+	if status == "active" {
+		return nil, fmt.Errorf("session '%s' is still active — cannot resume an active session", s.ID)
+	}
+	if status == "stale" {
+		return nil, fmt.Errorf("session '%s' workspace no longer exists", s.ID)
+	}
+
+	cfg, err := agent.LoadFrom(filepath.Join(opts.WorkspaceDir, ".toc", "agents", s.Agent))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load agent config: %w", err)
+	}
+
+	agentDir := filepath.Join(opts.WorkspaceDir, ".toc", "agents", s.Agent)
+
+	// Re-resolve skills in case they were cleaned up
+	var failedSkills []string
+	if len(cfg.Skills) > 0 {
+		failedSkills = resolveSkills(s.WorkspacePath, cfg.Skills)
+	}
+
+	// Re-setup hooks
+	if err := setupHooks(s.WorkspacePath, agentDir, cfg); err != nil {
+		return nil, fmt.Errorf("failed to setup hooks: %w", err)
+	}
+
+	// Clean up previous exit code marker so ResolvedStatus works correctly
+	os.Remove(filepath.Join(s.WorkspacePath, "toc-exit-code.txt"))
+	os.Remove(filepath.Join(s.WorkspacePath, "toc-output.txt"))
+
+	// Update session status back to active
+	_ = session.UpdateStatusInWorkspace(opts.WorkspaceDir, s.ID, session.StatusActive)
+
+	outputPath := filepath.Join(s.WorkspacePath, "toc-output.txt")
+	if err := launchClaudeDetachedResume(s.WorkspacePath, cfg.Model, s.ID, opts.Prompt, opts.WorkspaceDir, s.Agent, outputPath); err != nil {
+		return nil, fmt.Errorf("failed to resume sub-agent: %w", err)
+	}
+
+	return &SpawnResult{SessionID: s.ID, FailedSkills: failedSkills}, nil
+}
+
 // launchClaudeDetached starts claude in a detached process via a wrapper script
 // so the sub-agent outlives the parent toc process.
 func launchClaudeDetached(dir, model, prompt, workspace, agentName, sessionID, outputPath string) error {
@@ -251,14 +306,17 @@ func launchClaudeDetached(dir, model, prompt, workspace, agentName, sessionID, o
 	// but ResolvedStatus checks for toc-output.txt existence as the completion signal.
 	// Without the rename, the parent sees "completed" before claude even starts.
 	tmpOutputPath := outputPath + ".tmp"
+	exitCodePath := filepath.Join(dir, "toc-exit-code.txt")
 	scriptContent := fmt.Sprintf(`#!/bin/sh
 cd %q
 export TOC_WORKSPACE=%q
 export TOC_AGENT=%q
 export TOC_SESSION_ID=%q
 %s < /dev/null > %q 2>&1
+exit_code=$?
+echo $exit_code > %q
 mv %q %q
-`, dir, workspace, agentName, sessionID, args, tmpOutputPath, tmpOutputPath, outputPath)
+`, dir, workspace, agentName, sessionID, args, tmpOutputPath, exitCodePath, tmpOutputPath, outputPath)
 
 	scriptPath := filepath.Join(dir, "toc-run.sh")
 	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0755); err != nil {
@@ -277,6 +335,55 @@ mv %q %q
 	}
 
 	// Release the process so it's not waited on
+	return cmd.Process.Release()
+}
+
+// launchClaudeDetachedResume starts claude in a detached process that resumes
+// an existing conversation via --resume.
+func launchClaudeDetachedResume(dir, model, sessionID, prompt, workspace, agentName, outputPath string) error {
+	// Build claude command with --resume to continue the existing conversation.
+	args := fmt.Sprintf("claude --dangerously-skip-permissions -p --resume %q", sessionID)
+	if model != "" {
+		args += fmt.Sprintf(" --model %s", model)
+	}
+
+	// If a prompt is provided, write it to a file and pass it as the prompt argument.
+	if prompt != "" {
+		promptPath := filepath.Join(dir, "toc-prompt.txt")
+		if err := os.WriteFile(promptPath, []byte(prompt), 0644); err != nil {
+			return err
+		}
+		args += fmt.Sprintf(" \"$(cat %q)\"", promptPath)
+	}
+
+	tmpOutputPath := outputPath + ".tmp"
+	exitCodePath := filepath.Join(dir, "toc-exit-code.txt")
+	scriptContent := fmt.Sprintf(`#!/bin/sh
+cd %q
+export TOC_WORKSPACE=%q
+export TOC_AGENT=%q
+export TOC_SESSION_ID=%q
+%s < /dev/null > %q 2>&1
+exit_code=$?
+echo $exit_code > %q
+mv %q %q
+`, dir, workspace, agentName, sessionID, args, tmpOutputPath, exitCodePath, tmpOutputPath, outputPath)
+
+	scriptPath := filepath.Join(dir, "toc-run.sh")
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0755); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Dir = dir
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
 	return cmd.Process.Release()
 }
 


### PR DESCRIPTION
## Summary
- Adds `--resume <session-id>` flag to `toc runtime spawn` so failed/completed sub-agent sessions can be resumed without restarting from scratch
- Tracks exit codes via `toc-exit-code.txt` so session status distinguishes completed vs failed vs active
- Prevents double-resume of active sessions
- Resumed sessions reuse existing workspace, conversation history, and permission manifest
- Shows resume hint when `toc runtime status` displays a failed session

Fixes #39

## Implementation notes
- Resume uses `claude --print --resume <session-id>` to continue the existing conversation
- Optional `--prompt` adds context for the resumed session (e.g., "you crashed, check git status and continue")
- `--prompt` is no longer required when `--resume` is provided
- Exit code tracking is backwards-compatible — existing sessions without `toc-exit-code.txt` still resolve as completed

## Test plan
- [ ] Spawn a sub-agent, kill it mid-run, verify status shows "failed"
- [ ] Resume the failed session with `--resume`, verify it picks up conversation history
- [ ] Resume with `--prompt` to pass additional context
- [ ] Attempt to resume an active session — should be rejected
- [ ] Verify `toc runtime status` shows the failed badge and resume hint
- [ ] Verify existing (non-resumed) spawn flow still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)