### PR TITLE
Fix integration registry lookup to fetch from remote

### DIFF
--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -2,12 +2,16 @@ package integration
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+const remoteIntegrationBase = "https://raw.githubusercontent.com/louismorgner/tiny-oc/main/registry/integrations"
 
 // Definition represents an integration definition loaded from YAML.
 type Definition struct {
@@ -88,7 +92,42 @@ func LoadFromRegistry(name string) (*Definition, error) {
 		}
 	}
 
+	// Try fetching from remote registry
+	if def, err := fetchFromRemoteRegistry(name); err == nil {
+		return def, nil
+	}
+
 	return nil, fmt.Errorf("integration '%s' not found in registry", name)
+}
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+// fetchFromRemoteRegistry downloads an integration definition from the remote registry on GitHub.
+func fetchFromRemoteRegistry(name string) (*Definition, error) {
+	url := fmt.Sprintf("%s/%s/integration.yaml", remoteIntegrationBase, name)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var def Definition
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return nil, fmt.Errorf("failed to parse remote integration definition: %w", err)
+	}
+	if err := def.Validate(); err != nil {
+		return nil, err
+	}
+	return &def, nil
 }
 
 // Validate checks the definition for errors.


### PR DESCRIPTION
## Summary
- `toc integrate add slack` fails with `integration 'slack' not found in registry` because `LoadFromRegistry()` only checks local filesystem paths (relative to binary and cwd)
- Skills and agents already fetch from the remote GitHub registry via `raw.githubusercontent.com`, but integrations were missing this fallback
- Added `fetchFromRemoteRegistry()` that fetches `registry/integrations/<name>/integration.yaml` from GitHub raw content, matching the existing pattern in `internal/registry/registry.go`

## Test plan
- [ ] Run `toc integrate add slack` — should now find the definition and prompt for OAuth2 setup
- [ ] Run `toc integrate add nonexistent` — should still return "not found in registry"
- [ ] Run `toc integrate list` after adding an integration — description should resolve correctly
- [ ] Verify `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)