### PR TITLE
Add interactive TUI dashboard to toc status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 	"github.com/tiny-oc/toc/internal/agent"
 	"github.com/tiny-oc/toc/internal/config"
@@ -16,145 +18,169 @@ import (
 )
 
 func init() {
+	statusCmd.Flags().Bool("static", false, "Print once and exit (no live updates)")
 	rootCmd.AddCommand(statusCmd)
 }
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show workspace overview",
+	Long:  "Show a live-updating dashboard of workspace status. Use --static for a single snapshot.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.EnsureInitialized()
 		if err != nil {
 			return err
 		}
 
-		agents, err := agent.List()
-		if err != nil {
+		static, _ := cmd.Flags().GetBool("static")
+
+		// Use interactive TUI unless --static is set or stdout is not a terminal
+		if !static && isTerminal() {
+			m := initialModel(cfg)
+			p := tea.NewProgram(m)
+			_, err := p.Run()
 			return err
 		}
 
-		sf, err := session.Load()
-		if err != nil {
-			return err
-		}
-
-		fmt.Println()
-		fmt.Printf("  %s %s\n", ui.Bold("Workspace:"), ui.Cyan(cfg.Name))
-		fmt.Printf("  %s %s\n", ui.Bold("Config:"), ui.Dim(config.TocDir()+"/"))
-		fmt.Println()
-
-		// Build per-agent token totals
-		agentTokens := make(map[string]usage.TokenUsage)
-		var totalTokens usage.TokenUsage
-		for _, s := range sf.Sessions {
-			tokens := usage.ForSession(s.WorkspacePath, s.ID)
-			combined := agentTokens[s.Agent]
-			combined.InputTokens += tokens.InputTokens
-			combined.OutputTokens += tokens.OutputTokens
-			combined.CacheRead += tokens.CacheRead
-			combined.CacheCreate += tokens.CacheCreate
-			agentTokens[s.Agent] = combined
-			totalTokens.InputTokens += tokens.InputTokens
-			totalTokens.OutputTokens += tokens.OutputTokens
-			totalTokens.CacheRead += tokens.CacheRead
-			totalTokens.CacheCreate += tokens.CacheCreate
-		}
-
-		// Agents
-		fmt.Printf("  %s", ui.Bold("Agents"))
-		if len(agents) == 0 {
-			fmt.Printf("  %s\n", ui.Dim("none"))
-			fmt.Printf("  %s\n", ui.Dim("Run 'toc agent create' to get started."))
-		} else {
-			totalStr := totalTokens.FormatTotal()
-			if totalStr != "" {
-				fmt.Printf(" %s %s\n", ui.Dim(fmt.Sprintf("(%d)", len(agents))), ui.Dim("— "+totalStr+" total"))
-			} else {
-				fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d)", len(agents))))
-			}
-			for _, a := range agents {
-				problems := a.Validate()
-				if len(problems) == 0 {
-					desc := ""
-					if a.Description != "" {
-						desc = " " + ui.Dim("— "+a.Description)
-					}
-					tokenStr := agentTokens[a.Name].FormatTotal()
-					if tokenStr != "" {
-						desc += " " + ui.Dim("["+tokenStr+"]")
-					}
-					fmt.Printf("    %s %s %s%s\n", ui.Green("✓"), ui.Cyan(a.Name), ui.Dim(a.Model), desc)
-				} else {
-					fmt.Printf("    %s %s %s\n", ui.Red("✗"), ui.Cyan(a.Name), ui.Red(strings.Join(problems, ", ")))
-				}
-				if len(a.Skills) > 0 {
-					fmt.Printf("      %s %s\n", ui.Dim("skills:"), ui.Dim(strings.Join(a.Skills, ", ")))
-				}
-			}
-		}
-		fmt.Println()
-
-		// Skills
-		locals, _ := skill.ListLocal()
-		reg, _ := skill.LoadRegistry()
-		totalSkills := len(locals) + len(reg.Skills)
-		fmt.Printf("  %s", ui.Bold("Skills"))
-		if totalSkills == 0 {
-			fmt.Printf("  %s\n", ui.Dim("none"))
-		} else {
-			fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d)", totalSkills)))
-			for _, s := range locals {
-				desc := s.Description
-				if len(desc) > 50 {
-					desc = desc[:47] + "..."
-				}
-				fmt.Printf("    %s %s %s\n", ui.Dim("▪"), ui.Cyan(s.Name), ui.Dim(desc))
-			}
-			for _, r := range reg.Skills {
-				fmt.Printf("    %s %s %s\n", ui.Dim("▪"), ui.Cyan(r.Name), ui.Dim(r.URL))
-			}
-		}
-		fmt.Println()
-
-		// Recent sessions
-		fmt.Printf("  %s", ui.Bold("Recent sessions"))
-		if len(sf.Sessions) == 0 {
-			fmt.Printf("  %s\n", ui.Dim("none"))
-		} else {
-			shown := make([]session.Session, len(sf.Sessions))
-			copy(shown, sf.Sessions)
-			sort.Slice(shown, func(i, j int) bool {
-				return shown[i].CreatedAt.After(shown[j].CreatedAt)
-			})
-			if len(shown) > 5 {
-				shown = shown[:5]
-			}
-			fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d total)", len(sf.Sessions))))
-			for _, s := range shown {
-				age := timeAgo(s.CreatedAt)
-				status := s.ResolvedStatus()
-				var badge string
-				switch status {
-				case "active":
-					badge = ui.Green("● active")
-				case "completed":
-					badge = ui.Dim("○ completed")
-				case "stale":
-					badge = ui.Yellow("◌ stale")
-				}
-				tokens := usage.ForSession(s.WorkspacePath, s.ID)
-				tokenStr := tokens.FormatTotal()
-				if tokenStr != "" {
-					fmt.Printf("    %s  %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]), ui.Dim(tokenStr))
-				} else {
-					fmt.Printf("    %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
-				}
-			}
-		}
-		fmt.Println()
-
-		return nil
+		return printStaticStatus(cfg)
 	},
+}
+
+func isTerminal() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func printStaticStatus(cfg *config.WorkspaceConfig) error {
+	agents, err := agent.List()
+	if err != nil {
+		return err
+	}
+
+	sf, err := session.Load()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Printf("  %s %s\n", ui.Bold("Workspace:"), ui.Cyan(cfg.Name))
+	fmt.Printf("  %s %s\n", ui.Bold("Config:"), ui.Dim(config.TocDir()+"/"))
+	fmt.Println()
+
+	// Build per-agent token totals
+	agentTokens := make(map[string]usage.TokenUsage)
+	var totalTokens usage.TokenUsage
+	for _, s := range sf.Sessions {
+		tokens := usage.ForSession(s.WorkspacePath, s.ID)
+		combined := agentTokens[s.Agent]
+		combined.InputTokens += tokens.InputTokens
+		combined.OutputTokens += tokens.OutputTokens
+		combined.CacheRead += tokens.CacheRead
+		combined.CacheCreate += tokens.CacheCreate
+		agentTokens[s.Agent] = combined
+		totalTokens.InputTokens += tokens.InputTokens
+		totalTokens.OutputTokens += tokens.OutputTokens
+		totalTokens.CacheRead += tokens.CacheRead
+		totalTokens.CacheCreate += tokens.CacheCreate
+	}
+
+	// Agents
+	fmt.Printf("  %s", ui.Bold("Agents"))
+	if len(agents) == 0 {
+		fmt.Printf("  %s\n", ui.Dim("none"))
+		fmt.Printf("  %s\n", ui.Dim("Run 'toc agent create' to get started."))
+	} else {
+		totalStr := totalTokens.FormatTotal()
+		if totalStr != "" {
+			fmt.Printf(" %s %s\n", ui.Dim(fmt.Sprintf("(%d)", len(agents))), ui.Dim("— "+totalStr+" total"))
+		} else {
+			fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d)", len(agents))))
+		}
+		for _, a := range agents {
+			problems := a.Validate()
+			if len(problems) == 0 {
+				desc := ""
+				if a.Description != "" {
+					desc = " " + ui.Dim("— "+a.Description)
+				}
+				tokenStr := agentTokens[a.Name].FormatTotal()
+				if tokenStr != "" {
+					desc += " " + ui.Dim("["+tokenStr+"]")
+				}
+				fmt.Printf("    %s %s %s%s\n", ui.Green("✓"), ui.Cyan(a.Name), ui.Dim(a.Model), desc)
+			} else {
+				fmt.Printf("    %s %s %s\n", ui.Red("✗"), ui.Cyan(a.Name), ui.Red(strings.Join(problems, ", ")))
+			}
+			if len(a.Skills) > 0 {
+				fmt.Printf("      %s %s\n", ui.Dim("skills:"), ui.Dim(strings.Join(a.Skills, ", ")))
+			}
+		}
+	}
+	fmt.Println()
+
+	// Skills
+	locals, _ := skill.ListLocal()
+	reg, _ := skill.LoadRegistry()
+	totalSkills := len(locals) + len(reg.Skills)
+	fmt.Printf("  %s", ui.Bold("Skills"))
+	if totalSkills == 0 {
+		fmt.Printf("  %s\n", ui.Dim("none"))
+	} else {
+		fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d)", totalSkills)))
+		for _, s := range locals {
+			desc := s.Description
+			if len(desc) > 50 {
+				desc = desc[:47] + "..."
+			}
+			fmt.Printf("    %s %s %s\n", ui.Dim("▪"), ui.Cyan(s.Name), ui.Dim(desc))
+		}
+		for _, r := range reg.Skills {
+			fmt.Printf("    %s %s %s\n", ui.Dim("▪"), ui.Cyan(r.Name), ui.Dim(r.URL))
+		}
+	}
+	fmt.Println()
+
+	// Recent sessions
+	fmt.Printf("  %s", ui.Bold("Recent sessions"))
+	if len(sf.Sessions) == 0 {
+		fmt.Printf("  %s\n", ui.Dim("none"))
+	} else {
+		shown := make([]session.Session, len(sf.Sessions))
+		copy(shown, sf.Sessions)
+		sort.Slice(shown, func(i, j int) bool {
+			return shown[i].CreatedAt.After(shown[j].CreatedAt)
+		})
+		if len(shown) > 5 {
+			shown = shown[:5]
+		}
+		fmt.Printf(" %s\n", ui.Dim(fmt.Sprintf("(%d total)", len(sf.Sessions))))
+		for _, s := range shown {
+			age := timeAgo(s.CreatedAt)
+			status := s.ResolvedStatus()
+			var badge string
+			switch status {
+			case "active":
+				badge = ui.Green("● active")
+			case "completed":
+				badge = ui.Dim("○ completed")
+			case "stale":
+				badge = ui.Yellow("◌ stale")
+			}
+			tokens := usage.ForSession(s.WorkspacePath, s.ID)
+			tokenStr := tokens.FormatTotal()
+			if tokenStr != "" {
+				fmt.Printf("    %s  %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]), ui.Dim(tokenStr))
+			} else {
+				fmt.Printf("    %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
+			}
+		}
+	}
+	fmt.Println()
+
+	return nil
 }
 
 func timeAgo(t time.Time) string {

--- a/cmd/status_tui.go
+++ b/cmd/status_tui.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/tiny-oc/toc/internal/agent"
+	"github.com/tiny-oc/toc/internal/config"
+	"github.com/tiny-oc/toc/internal/session"
+	"github.com/tiny-oc/toc/internal/usage"
+)
+
+const refreshInterval = 2 * time.Second
+
+type tickMsg time.Time
+
+type statusModel struct {
+	cfg      *config.WorkspaceConfig
+	agents   []agent.AgentConfig
+	sessions []session.Session
+	err      error
+	width    int
+	height   int
+	quitting bool
+}
+
+func initialModel(cfg *config.WorkspaceConfig) statusModel {
+	m := statusModel{cfg: cfg}
+	m.refresh()
+	return m
+}
+
+func (m *statusModel) refresh() {
+	agents, err := agent.List()
+	if err != nil {
+		m.err = err
+		return
+	}
+	m.agents = agents
+
+	sf, err := session.Load()
+	if err != nil {
+		m.err = err
+		return
+	}
+	m.sessions = sf.Sessions
+}
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(refreshInterval, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}
+
+func (m statusModel) Init() tea.Cmd {
+	return tickCmd()
+}
+
+func (m statusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "q", "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	case tickMsg:
+		m.refresh()
+		return m, tickCmd()
+	}
+	return m, nil
+}
+
+func (m statusModel) View() tea.View {
+	if m.quitting {
+		return tea.NewView("")
+	}
+	if m.err != nil {
+		return tea.NewView(fmt.Sprintf("  Error: %v\n", m.err))
+	}
+
+	var b strings.Builder
+
+	dim := lipgloss.NewStyle().Faint(true).Render
+	bold := lipgloss.NewStyle().Bold(true).Render
+	cyan := lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Render
+	green := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render
+	yellow := lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render
+	red := lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render
+
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  %s %s\n", bold("Workspace:"), cyan(m.cfg.Name)))
+	b.WriteString(fmt.Sprintf("  %s %s\n", bold("Config:"), dim(config.TocDir()+"/")))
+	b.WriteString("\n")
+
+	// Token totals per agent
+	agentTokens := make(map[string]usage.TokenUsage)
+	var totalTokens usage.TokenUsage
+	for _, s := range m.sessions {
+		tokens := usage.ForSession(s.WorkspacePath, s.ID)
+		combined := agentTokens[s.Agent]
+		combined.InputTokens += tokens.InputTokens
+		combined.OutputTokens += tokens.OutputTokens
+		combined.CacheRead += tokens.CacheRead
+		combined.CacheCreate += tokens.CacheCreate
+		agentTokens[s.Agent] = combined
+		totalTokens.InputTokens += tokens.InputTokens
+		totalTokens.OutputTokens += tokens.OutputTokens
+		totalTokens.CacheRead += tokens.CacheRead
+		totalTokens.CacheCreate += tokens.CacheCreate
+	}
+
+	// Agents
+	b.WriteString(fmt.Sprintf("  %s", bold("Agents")))
+	if len(m.agents) == 0 {
+		b.WriteString(fmt.Sprintf("  %s\n", dim("none")))
+	} else {
+		totalStr := totalTokens.FormatTotal()
+		if totalStr != "" {
+			b.WriteString(fmt.Sprintf(" %s %s\n", dim(fmt.Sprintf("(%d)", len(m.agents))), dim("— "+totalStr+" total")))
+		} else {
+			b.WriteString(fmt.Sprintf(" %s\n", dim(fmt.Sprintf("(%d)", len(m.agents)))))
+		}
+		for _, a := range m.agents {
+			problems := a.Validate()
+			if len(problems) == 0 {
+				desc := ""
+				if a.Description != "" {
+					desc = " " + dim("— "+a.Description)
+				}
+				tokenStr := agentTokens[a.Name].FormatTotal()
+				if tokenStr != "" {
+					desc += " " + dim("["+tokenStr+"]")
+				}
+				b.WriteString(fmt.Sprintf("    %s %s %s%s\n", green("✓"), cyan(a.Name), dim(a.Model), desc))
+			} else {
+				b.WriteString(fmt.Sprintf("    %s %s %s\n", red("✗"), cyan(a.Name), red(strings.Join(problems, ", "))))
+			}
+		}
+	}
+	b.WriteString("\n")
+
+	// Sessions
+	b.WriteString(fmt.Sprintf("  %s", bold("Sessions")))
+	if len(m.sessions) == 0 {
+		b.WriteString(fmt.Sprintf("  %s\n", dim("none")))
+	} else {
+		active, completed, failed := 0, 0, 0
+		for i := range m.sessions {
+			switch m.sessions[i].ResolvedStatus() {
+			case "active":
+				active++
+			case "completed", session.StatusCompletedOK:
+				completed++
+			case session.StatusCompletedError, session.StatusZombie:
+				failed++
+			}
+		}
+		summary := fmt.Sprintf("(%d total", len(m.sessions))
+		if active > 0 {
+			summary += fmt.Sprintf(", %d active", active)
+		}
+		if failed > 0 {
+			summary += fmt.Sprintf(", %d failed", failed)
+		}
+		summary += ")"
+		b.WriteString(fmt.Sprintf(" %s\n", dim(summary)))
+
+		shown := make([]session.Session, len(m.sessions))
+		copy(shown, m.sessions)
+		sort.Slice(shown, func(i, j int) bool {
+			return shown[i].CreatedAt.After(shown[j].CreatedAt)
+		})
+
+		limit := 15
+		if len(shown) < limit {
+			limit = len(shown)
+		}
+		shown = shown[:limit]
+
+		for _, s := range shown {
+			age := timeAgo(s.CreatedAt)
+			status := s.ResolvedStatus()
+			var badge string
+			switch status {
+			case "active":
+				badge = green("● active   ")
+			case "completed", session.StatusCompletedOK:
+				badge = dim("○ completed")
+			case session.StatusCompletedError:
+				badge = red("✗ error    ")
+			case session.StatusZombie:
+				badge = red("◌ zombie   ")
+			case session.StatusCancelled:
+				badge = yellow("◌ cancelled")
+			case "stale":
+				badge = yellow("◌ stale    ")
+			default:
+				badge = dim("○ " + status + strings.Repeat(" ", maxInt(0, 9-len(status))))
+			}
+
+			idStr := s.ID
+			if len(idStr) > 8 {
+				idStr = idStr[:8]
+			}
+
+			parent := ""
+			if s.ParentSessionID != "" {
+				pid := s.ParentSessionID
+				if len(pid) > 8 {
+					pid = pid[:8]
+				}
+				parent = dim(" ← " + pid)
+			}
+
+			tokens := usage.ForSession(s.WorkspacePath, s.ID)
+			tokenStr := tokens.FormatTotal()
+			tokenCol := ""
+			if tokenStr != "" {
+				tokenCol = "  " + dim(tokenStr)
+			}
+
+			b.WriteString(fmt.Sprintf("    %s  %-12s  %-14s  %s%s%s\n",
+				badge, cyan(s.Agent), dim(age), dim(idStr), parent, tokenCol))
+		}
+		if len(m.sessions) > limit {
+			b.WriteString(fmt.Sprintf("    %s\n", dim(fmt.Sprintf("... and %d more", len(m.sessions)-limit))))
+		}
+	}
+	b.WriteString("\n")
+
+	// Footer
+	b.WriteString(fmt.Sprintf("  %s  %s\n",
+		dim("Refreshing every 2s"),
+		dim("Press q to quit")))
+
+	v := tea.NewView(b.String())
+	v.AltScreen = true
+	return v
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/tiny-oc/toc
 go 1.25.8
 
 require (
+	charm.land/bubbletea/v2 v2.0.2
 	charm.land/huh/v2 v2.0.3
+	charm.land/lipgloss/v2 v2.0.1
 	github.com/fatih/color v1.19.0
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
@@ -12,8 +14,6 @@ require (
 
 require (
 	charm.land/bubbles/v2 v2.0.0 // indirect
-	charm.land/bubbletea/v2 v2.0.2 // indirect
-	charm.land/lipgloss/v2 v2.0.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect


### PR DESCRIPTION
## Summary
- **Default behavior changed**: `toc status` now shows a live-updating Bubbletea TUI dashboard that auto-refreshes every 2 seconds, showing active/completed/failed sessions, agent info, token usage, and parent-child relationships
- **`--static` flag added**: Preserves the previous print-once-and-exit behavior for scripting and CI pipelines
- **Auto-detection**: Falls back to static mode when stdout is not a TTY (piped output, redirected to file)

## Details
- New `cmd/status_tui.go` implements a `tea.Model` using Bubbletea v2 with alt-screen rendering
- Shows up to 15 sessions (vs 5 in static mode) with richer status badges (error, zombie, cancelled states)
- Displays parent-child session relationships inline
- Promoted `charm.land/bubbletea/v2` and `charm.land/lipgloss/v2` from indirect to direct dependencies (already in the dep tree via `huh`)
- No new external dependencies added

## Test plan
- [ ] Run `toc status` in a terminal — should show live TUI with alt-screen, press `q` to exit
- [ ] Run `toc status --static` — should show the original single-snapshot output
- [ ] Run `toc status | cat` — should auto-detect non-TTY and print static output
- [ ] Verify `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)