### PR TITLE
Show assistant text messages in runtime watch output

### DIFF
--- a/cmd/runtime_replay.go
+++ b/cmd/runtime_replay.go
@@ -111,7 +111,7 @@ func printReplayHuman(r *replay.Replay, thinkingOnly, actionsOnly, compact, full
 			continue
 		}
 
-		printStep(step, compact)
+		printStep(step, printOpts{HideText: compact})
 	}
 
 	fmt.Println()
@@ -125,61 +125,95 @@ func printReplayHuman(r *replay.Replay, thinkingOnly, actionsOnly, compact, full
 	return nil
 }
 
-func printStep(step replay.Step, compact bool) {
+// printOpts controls how steps are rendered.
+type printOpts struct {
+	HideText    bool // compact mode: don't show text/assistant steps
+	FullContent bool // verbose mode: show full content without truncation
+}
+
+func printStep(step replay.Step, opts printOpts) {
 	switch step.Type {
 	case "thinking":
-		text := replay.TruncateThinking(step.Content, 100)
-		fmt.Printf("  %s %s\n", ui.Dim("[think]"), ui.Dim(text))
-	case "text":
-		if !compact {
+		if opts.FullContent {
+			printMultiLine("[think]    ", step.Content, ui.Dim)
+		} else {
 			text := replay.TruncateThinking(step.Content, 100)
-			fmt.Printf("  %s %s\n", ui.Dim("[text] "), ui.Dim(text))
+			fmt.Printf("  %s %s\n", ui.Dim("[think]    "), ui.Dim(text))
+		}
+	case "text":
+		if !opts.HideText {
+			if opts.FullContent {
+				printMultiLine("[assistant]", step.Content, nil)
+			} else {
+				text := replay.TruncateThinking(step.Content, 120)
+				fmt.Printf("  %s %s\n", ui.Cyan("[assistant]"), text)
+			}
 		}
 	case "tool":
 		printToolStep(step)
 	case "skill":
-		fmt.Printf("  %s %s\n", ui.Yellow("[skill]"), ui.Cyan(step.Skill))
+		fmt.Printf("  %s %s\n", ui.Yellow("[skill]    "), ui.Cyan(step.Skill))
 	case "error":
 		text := step.Content
 		if len(text) > 100 {
 			text = text[:97] + "..."
 		}
-		fmt.Printf("  %s %s\n", ui.Red("[error]"), text)
+		fmt.Printf("  %s %s\n", ui.Red("[error]    "), text)
+	}
+}
+
+// printMultiLine prints a labeled block with wrapped/indented content.
+func printMultiLine(label, content string, colorFn func(a ...interface{}) string) {
+	lines := strings.Split(content, "\n")
+	indent := strings.Repeat(" ", 2+len(label)+1) // "  " + label + " "
+	for i, line := range lines {
+		if colorFn != nil {
+			line = colorFn(line)
+		}
+		if i == 0 {
+			if colorFn != nil {
+				fmt.Printf("  %s %s\n", ui.Dim(label), line)
+			} else {
+				fmt.Printf("  %s %s\n", ui.Cyan(label), line)
+			}
+		} else {
+			fmt.Printf("%s%s\n", indent, line)
+		}
 	}
 }
 
 func printToolStep(step replay.Step) {
 	switch step.Tool {
 	case "Read":
-		fmt.Printf("  %s %s\n", ui.Dim("[read] "), shortPath(step.Path))
+		fmt.Printf("  %s %s\n", ui.Dim("[read]     "), shortPath(step.Path))
 	case "Edit":
 		detail := ""
 		if step.Added > 0 || step.Removed > 0 {
 			detail = fmt.Sprintf(" +%d -%d lines", step.Added, step.Removed)
 		}
-		fmt.Printf("  %s %s%s\n", ui.Dim("[edit] "), shortPath(step.Path), ui.Dim(detail))
+		fmt.Printf("  %s %s%s\n", ui.Dim("[edit]     "), shortPath(step.Path), ui.Dim(detail))
 	case "Write":
 		detail := ""
 		if step.Lines > 0 {
 			detail = fmt.Sprintf(" %d lines", step.Lines)
 		}
-		fmt.Printf("  %s %s%s\n", ui.Dim("[write]"), shortPath(step.Path), ui.Dim(detail))
+		fmt.Printf("  %s %s%s\n", ui.Dim("[write]    "), shortPath(step.Path), ui.Dim(detail))
 	case "Bash":
 		cmd := step.Command
 		if len(cmd) > 80 {
 			cmd = cmd[:77] + "..."
 		}
-		fmt.Printf("  %s %s\n", ui.Dim("[bash] "), cmd)
+		fmt.Printf("  %s %s\n", ui.Dim("[bash]     "), cmd)
 	case "Glob":
-		fmt.Printf("  %s %s\n", ui.Dim("[glob] "), step.Content)
+		fmt.Printf("  %s %s\n", ui.Dim("[glob]     "), step.Content)
 	case "Grep":
-		fmt.Printf("  %s %s\n", ui.Dim("[grep] "), step.Content)
+		fmt.Printf("  %s %s\n", ui.Dim("[grep]     "), step.Content)
 	default:
 		detail := step.Tool
 		if step.Path != "" {
 			detail += " " + shortPath(step.Path)
 		}
-		fmt.Printf("  %s %s\n", ui.Dim("[tool] "), detail)
+		fmt.Printf("  %s %s\n", ui.Dim("[tool]     "), detail)
 	}
 }
 

--- a/cmd/runtime_watch.go
+++ b/cmd/runtime_watch.go
@@ -18,6 +18,7 @@ import (
 
 func init() {
 	runtimeWatchCmd.Flags().Bool("json", false, "Output each step as newline-delimited JSON")
+	runtimeWatchCmd.Flags().BoolP("verbose", "v", false, "Show full assistant messages and thinking blocks")
 	runtimeCmd.AddCommand(runtimeWatchCmd)
 }
 
@@ -52,11 +53,12 @@ var runtimeWatchCmd = &cobra.Command{
 		}
 
 		jsonFlag, _ := cmd.Flags().GetBool("json")
+		verbose, _ := cmd.Flags().GetBool("verbose")
 
 		// If session is already completed, replay all steps and exit
 		status := s.ResolvedStatus()
 		if status == "completed" || status == "failed" {
-			return watchCompleted(s, jsonFlag, status)
+			return watchCompleted(s, jsonFlag, verbose, status)
 		}
 
 		// Resolve JSONL path — use existing file if available, otherwise
@@ -96,8 +98,8 @@ var runtimeWatchCmd = &cobra.Command{
 				return nil
 			}
 
-			// Compact mode: skip thinking steps for scannable output
-			if !jsonFlag && event.Step.Type == "thinking" {
+			// Skip thinking unless verbose
+			if !jsonFlag && !verbose && event.Step.Type == "thinking" {
 				continue
 			}
 
@@ -105,7 +107,7 @@ var runtimeWatchCmd = &cobra.Command{
 				data, _ := json.Marshal(event.Step)
 				fmt.Println(string(data))
 			} else {
-				printStep(event.Step, true)
+				printStep(event.Step, printOpts{FullContent: verbose})
 			}
 		}
 
@@ -116,7 +118,7 @@ var runtimeWatchCmd = &cobra.Command{
 	},
 }
 
-func watchCompleted(s *session.Session, jsonFlag bool, status string) error {
+func watchCompleted(s *session.Session, jsonFlag, verbose bool, status string) error {
 	r, err := replay.ForSession(s)
 	if err != nil {
 		return err
@@ -129,11 +131,11 @@ func watchCompleted(s *session.Session, jsonFlag bool, status string) error {
 		}
 	} else {
 		for _, step := range r.Steps {
-			// Compact mode: skip thinking, show tools and text
-			if step.Type == "thinking" {
+			// Skip thinking unless verbose
+			if !verbose && step.Type == "thinking" {
 				continue
 			}
-			printStep(step, true)
+			printStep(step, printOpts{FullContent: verbose})
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Fix**: `toc runtime watch` was suppressing all assistant text messages because it hardcoded `compact=true` when calling `printStep`. Now text steps are shown by default, truncated to 120 chars for readability.
- **New flag**: `--verbose` / `-v` shows full untruncated assistant messages and thinking blocks.
- **Visual**: Assistant messages use `[assistant]` label in cyan to clearly distinguish them from tool calls. All labels aligned to 11-char width.

### Before
```
  [read]  tiny-oc/cmd/status.go
  [bash]  cd /path && go build ./...
  [write] tiny-oc/cmd/status_tui.go 257 lines
```

### After (default)
```
  [assistant] I'll start by reading the status command code...
  [read]      tiny-oc/cmd/status.go
  [assistant] Now I'll create the TUI model...
  [write]     tiny-oc/cmd/status_tui.go 257 lines
```

### After (--verbose)
```
  [think]     Let me analyze the existing code structure...
  [assistant] I'll start by reading the status command code
              to understand the current implementation before
              making any changes.
  [read]      tiny-oc/cmd/status.go
```

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `toc runtime watch <session-id>` shows assistant text between tool calls
- [ ] `toc runtime watch --verbose <session-id>` shows full text + thinking blocks
- [ ] `toc runtime watch --json <session-id>` unchanged behavior
- [ ] `toc runtime replay <session-id>` still works with all existing flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)