### PR TITLE
feat: auto-generate session names from prompts

### DIFF
--- a/cmd/runtime_status.go
+++ b/cmd/runtime_status.go
@@ -44,6 +44,7 @@ var runtimeStatusCmd = &cobra.Command{
 
 type statusJSON struct {
 	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
 	Agent    string `json:"agent"`
 	Status   string `json:"status"`
 	Prompt   string `json:"prompt,omitempty"`
@@ -53,6 +54,7 @@ type statusJSON struct {
 func statusJSONForSession(s *session.Session) statusJSON {
 	sj := statusJSON{
 		ID:     s.ID,
+		Name:   s.Name,
 		Agent:  s.Agent,
 		Status: s.ResolvedStatus(),
 		Prompt: s.Prompt,
@@ -130,6 +132,9 @@ func showSubAgentStatus(ctx *runtime.Context, sessionID string) error {
 
 	fmt.Println()
 	fmt.Printf("  %s %s\n", ui.Bold("Agent:"), ui.Cyan(s.Agent))
+	if s.Name != "" {
+		fmt.Printf("  %s %s\n", ui.Bold("Name:"), ui.Cyan(s.Name))
+	}
 	fmt.Printf("  %s %s\n", ui.Bold("Status:"), badge)
 	fmt.Printf("  %s %s\n", ui.Bold("Session:"), ui.Dim(s.ID))
 	if exitCode, err := s.ReadExitCode(); err == nil {
@@ -172,18 +177,21 @@ func listSubAgentStatuses(ctx *runtime.Context) error {
 	}
 
 	fmt.Println()
-	fmt.Printf("  %-10s %-16s %-10s %s\n", ui.Bold("STATUS"), ui.Bold("AGENT"), ui.Bold("SESSION"), ui.Bold("PROMPT"))
+	fmt.Printf("  %-10s %-16s %-10s %s\n", ui.Bold("STATUS"), ui.Bold("AGENT"), ui.Bold("SESSION"), ui.Bold("NAME"))
 	fmt.Printf("  %-10s %-16s %-10s %s\n", ui.Dim("──────────"), ui.Dim("────────────────"), ui.Dim("──────────"), ui.Dim("────────────────────────────"))
 
 	for _, s := range children {
 		badge := statusBadge(s.ResolvedStatus())
 
-		prompt := s.Prompt
-		if len(prompt) > 40 {
-			prompt = prompt[:37] + "..."
+		label := s.Name
+		if label == "" {
+			label = s.Prompt
+		}
+		if len(label) > 40 {
+			label = label[:37] + "..."
 		}
 
-		fmt.Printf("  %-10s %-16s %-10s %s\n", badge, ui.Cyan(s.Agent), ui.Dim(s.ID[:8]), ui.Dim(prompt))
+		fmt.Printf("  %-10s %-16s %-10s %s\n", badge, ui.Cyan(s.Agent), ui.Dim(s.ID[:8]), ui.Dim(label))
 	}
 
 	fmt.Println()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -171,10 +171,14 @@ func printStaticStatus(cfg *config.WorkspaceConfig) error {
 			}
 			tokens := usage.ForSession(s.WorkspacePath, s.ID)
 			tokenStr := tokens.FormatTotal()
+			nameStr := ""
+			if s.Name != "" {
+				nameStr = "  " + ui.Cyan(s.Name)
+			}
 			if tokenStr != "" {
-				fmt.Printf("    %s  %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]), ui.Dim(tokenStr))
+				fmt.Printf("    %s  %s  %s  %s%s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]), nameStr, ui.Dim(tokenStr))
 			} else {
-				fmt.Printf("    %s  %s  %s  %s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]))
+				fmt.Printf("    %s  %s  %s  %s%s\n", badge, ui.Cyan(s.Agent), ui.Dim(age), ui.Dim(s.ID[:8]), nameStr)
 			}
 		}
 	}

--- a/cmd/status_tui.go
+++ b/cmd/status_tui.go
@@ -227,8 +227,13 @@ func (m statusModel) View() tea.View {
 				tokenCol = "  " + dim(tokenStr)
 			}
 
-			b.WriteString(fmt.Sprintf("    %s  %-12s  %-14s  %s%s%s\n",
-				badge, cyan(s.Agent), dim(age), dim(idStr), parent, tokenCol))
+			nameCol := ""
+			if s.Name != "" {
+				nameCol = "  " + cyan(s.Name)
+			}
+
+			b.WriteString(fmt.Sprintf("    %s  %-12s  %-14s  %s%s%s%s\n",
+				badge, cyan(s.Agent), dim(age), dim(idStr), nameCol, parent, tokenCol))
 		}
 		if len(m.sessions) > limit {
 			b.WriteString(fmt.Sprintf("    %s\n", dim(fmt.Sprintf("... and %d more", len(m.sessions)-limit))))

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -1,0 +1,55 @@
+package naming
+
+import (
+	"strings"
+	"unicode"
+)
+
+// FromPrompt generates a short human-readable name from a task prompt.
+// Returns empty string if no prompt is provided.
+func FromPrompt(prompt string) string {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return ""
+	}
+
+	// Take first line only
+	if idx := strings.IndexByte(prompt, '\n'); idx != -1 {
+		prompt = prompt[:idx]
+	}
+
+	// Lowercase and split into words
+	prompt = strings.ToLower(prompt)
+	words := strings.Fields(prompt)
+	if len(words) == 0 {
+		return ""
+	}
+
+	// Cap at 6 words
+	if len(words) > 6 {
+		words = words[:6]
+	}
+
+	name := strings.Join(words, " ")
+	name = cleanName(name)
+
+	// Truncate to 50 chars max without cutting mid-word
+	if len(name) > 50 {
+		name = name[:50]
+		if idx := strings.LastIndexByte(name, ' '); idx > 0 {
+			name = name[:idx]
+		}
+	}
+
+	return name
+}
+
+func cleanName(name string) string {
+	// Remove surrounding quotes
+	name = strings.Trim(name, `"'`)
+	// Remove trailing punctuation (keep hyphens and slashes)
+	name = strings.TrimRightFunc(name, func(r rune) bool {
+		return unicode.IsPunct(r) && r != '-' && r != '/'
+	})
+	return strings.TrimSpace(name)
+}

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -1,0 +1,25 @@
+package naming
+
+import "testing"
+
+func TestFromPrompt(t *testing.T) {
+	tests := []struct {
+		prompt string
+		want   string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"Fix the auth token refresh bug", "fix the auth token refresh bug"},
+		{"Fix the auth token refresh bug in the OAuth handler for multi-tenant environments", "fix the auth token refresh bug"},
+		{"IMPLEMENT user search\nMore details here", "implement user search"},
+		{`"refactor database queries"`, "refactor database queries"},
+		{"add logging.", "add logging"},
+	}
+
+	for _, tt := range tests {
+		got := FromPrompt(tt.prompt)
+		if got != tt.want {
+			t.Errorf("FromPrompt(%q) = %q, want %q", tt.prompt, got, tt.want)
+		}
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -24,6 +24,7 @@ const (
 
 type Session struct {
 	ID              string    `yaml:"id"`
+	Name            string    `yaml:"name,omitempty"`
 	Agent           string    `yaml:"agent"`
 	CreatedAt       time.Time `yaml:"created_at"`
 	WorkspacePath   string    `yaml:"workspace_path"`

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tiny-oc/toc/internal/fileutil"
 	"github.com/tiny-oc/toc/internal/gitutil"
 	"github.com/tiny-oc/toc/internal/integration"
+	"github.com/tiny-oc/toc/internal/naming"
 	"github.com/tiny-oc/toc/internal/registry"
 	"github.com/tiny-oc/toc/internal/session"
 	"github.com/tiny-oc/toc/internal/skill"
@@ -212,6 +213,7 @@ func SpawnSubSession(cfg *agent.AgentConfig, opts SubSpawnOpts) (*SpawnResult, e
 
 	if err := session.AddInWorkspace(opts.WorkspaceDir, session.Session{
 		ID:              sessionID,
+		Name:            naming.FromPrompt(opts.Prompt),
 		Agent:           cfg.Name,
 		CreatedAt:       time.Now(),
 		WorkspacePath:   workDir,


### PR DESCRIPTION
## Summary

- Sessions spawned with `--prompt` now get a short human-readable name (first ~6 words of the prompt, lowercased)
- Names display in `toc status`, `toc runtime status`, and JSON output
- New `internal/naming` package with heuristic extraction and tests
- Zero external dependencies — no API keys or configuration needed

## What it looks like

```
# toc status
  Sessions (12 total, 2 active)
    ● active    atlas         3 mins ago      abc1def2  fix auth token refresh bug
    ● active    diana         15 mins ago     def3ghi4  implement slack oauth flow
    ○ completed atlas         2 hours ago     ghi5jkl6  add user search endpoint

# toc runtime status
  STATUS     AGENT            SESSION    NAME
  ──────────  ────────────────  ──────────  ────────────────────────────
  ● active   researcher       a1b2c3d4   review integration test coverage
  ● completed writer          e5f6g7h8   draft api documentation
```

## Design decisions

- **Heuristic only** — extracts first 6 words from prompt, no LLM call. Simple, instant, zero-config. LLM-powered naming can be added later behind an API key flag.
- **Sub-agent sessions only** — interactive sessions (`toc agent spawn`) have no prompt to derive a name from. The `Name` field is there for future use (manual naming, post-hoc naming from JSONL).
- **Backwards compatible** — `Name` is `omitempty` in YAML, so existing sessions.yaml files parse without issues.

## Test plan

- [x] `go test ./internal/naming/` — unit tests for name extraction edge cases
- [x] `go test ./...` — all existing tests pass
- [x] `go vet ./...` — clean
- [ ] Manual: `toc runtime spawn <agent> -p "some task"` → verify name appears in `toc runtime status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)