### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,12 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test $(go list ./... | grep -v /e2e)
+        run: go test -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v /e2e)
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
 
       - name: Vet
         run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # toc — tiny open company
 
+[![CI](https://github.com/louismorgner/tiny-oc/actions/workflows/ci.yaml/badge.svg)](https://github.com/louismorgner/tiny-oc/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/louismorgner/tiny-oc/branch/main/graph/badge.svg)](https://codecov.io/gh/louismorgner/tiny-oc)
+
 A local CLI tool for managing and spawning AI agent sessions from reusable templates.
 
 Define agents as simple YAML configs, then spawn isolated sessions instantly. Built for engineers who want fast, reproducible agent workflows without cloud dependencies.


### PR DESCRIPTION
## Summary

- Generate coverage profile (`-coverprofile=coverage.out -covermode=atomic`) during CI test step
- Upload coverage to Codecov via `codecov/codecov-action@v5` (tokenless for public repos)
- Add CI status and Codecov coverage badges to README

## Why Codecov

Most Go OSS projects use Codecov (Go stdlib, Kubernetes, Hugo, cobra). It provides:
- Coverage badge that updates automatically
- PR comments showing per-change coverage diff
- File-level coverage breakdown
- Zero maintenance — tokenless upload works for public repos

## Current coverage

| Package | Coverage |
|---------|----------|
| `internal/usage` | 60.7% |
| `internal/sync` | 52.6% |
| `internal/replay` | 42.8% |
| `internal/agent` | 35.1% |
| `internal/tail` | 33.8% |
| `internal/session` | 22.8% |
| `internal/integration` | 22.7% |
| `internal/spawn` | 4.0% |
| 9 other packages | 0% |

No coverage threshold enforced — visibility first, enforcement later when coverage improves.

## Test plan

- [ ] CI passes with coverage profile generation
- [ ] Codecov upload succeeds (check Actions log)
- [ ] Coverage badge renders in README after first upload
- [ ] Codecov bot posts coverage comment on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)