### PR TITLE
Remove Codecov from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,7 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v /e2e)
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.out
+        run: go test -cover $(go list ./... | grep -v /e2e)
 
       - name: Vet
         run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # toc — tiny open company
 
 [![CI](https://github.com/louismorgner/tiny-oc/actions/workflows/ci.yaml/badge.svg)](https://github.com/louismorgner/tiny-oc/actions/workflows/ci.yaml)
-[![codecov](https://codecov.io/gh/louismorgner/tiny-oc/branch/main/graph/badge.svg)](https://codecov.io/gh/louismorgner/tiny-oc)
 
 A local CLI tool for managing and spawning AI agent sessions from reusable templates.
 


### PR DESCRIPTION
## Summary
- Remove the `codecov/codecov-action@v5` step from CI workflow
- Remove the Codecov badge from README (CI badge retained)
- Simplify test command: `-coverprofile=coverage.out -covermode=atomic` → `-cover`

Follow-up to the simplification that didn't land before #64 was merged.

## Test plan
- [ ] CI passes without the Codecov step
- [ ] README renders correctly with only the CI badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)