### PR TITLE
Sort active sessions to top in toc status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -150,9 +150,7 @@ func printStaticStatus(cfg *config.WorkspaceConfig) error {
 	} else {
 		shown := make([]session.Session, len(sf.Sessions))
 		copy(shown, sf.Sessions)
-		sort.Slice(shown, func(i, j int) bool {
-			return shown[i].CreatedAt.After(shown[j].CreatedAt)
-		})
+		sortSessions(shown)
 		if len(shown) > 5 {
 			shown = shown[:5]
 		}
@@ -185,6 +183,18 @@ func printStaticStatus(cfg *config.WorkspaceConfig) error {
 	fmt.Println()
 
 	return nil
+}
+
+// sortSessions sorts active/running sessions first, then by most recent.
+func sortSessions(sessions []session.Session) {
+	sort.Slice(sessions, func(i, j int) bool {
+		ai := sessions[i].ResolvedStatus() == "active"
+		aj := sessions[j].ResolvedStatus() == "active"
+		if ai != aj {
+			return ai
+		}
+		return sessions[i].CreatedAt.After(sessions[j].CreatedAt)
+	})
 }
 
 func timeAgo(t time.Time) string {

--- a/cmd/status_tui.go
+++ b/cmd/status_tui.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -175,9 +174,7 @@ func (m statusModel) View() tea.View {
 
 		shown := make([]session.Session, len(m.sessions))
 		copy(shown, m.sessions)
-		sort.Slice(shown, func(i, j int) bool {
-			return shown[i].CreatedAt.After(shown[j].CreatedAt)
-		})
+		sortSessions(shown)
 
 		limit := 15
 		if len(shown) < limit {


### PR DESCRIPTION
## Summary
- Active/running sessions now sort to the top of the session list in both `toc status --static` and the TUI dashboard
- Within each group (active vs non-active), sessions remain sorted by most recent first
- Extracts shared `sortSessions` helper used by both views

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `toc status` with a mix of active and completed sessions — active ones should appear first

🤖 Generated with [Claude Code](https://claude.com/claude-code)