### PR TITLE
Show initial user message in watch and replay output

### DIFF
--- a/cmd/runtime_replay.go
+++ b/cmd/runtime_replay.go
@@ -133,6 +133,13 @@ type printOpts struct {
 
 func printStep(step replay.Step, opts printOpts) {
 	switch step.Type {
+	case "user":
+		if opts.FullContent {
+			printMultiLine("[user]     ", step.Content, nil)
+		} else {
+			text := replay.TruncateThinking(step.Content, 120)
+			fmt.Printf("  %s %s\n", ui.Green("[user]     "), text)
+		}
 	case "thinking":
 		if opts.FullContent {
 			printMultiLine("[think]    ", step.Content, ui.Dim)

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -260,11 +260,41 @@ func parseSessionJSONLFull(path string) (*parsedJSONL, error) {
 		}
 
 		switch entry.Type {
+		case "user":
+			result.Steps = append(result.Steps, parseUserMessage(entry.Message)...)
 		case "assistant":
 			result.Steps = append(result.Steps, parseAssistantMessage(entry.Message)...)
 		}
 	}
 	return result, nil
+}
+
+func parseUserMessage(raw json.RawMessage) []Step {
+	var msg messageEnvelope
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return nil
+	}
+	if msg.Role != "user" {
+		return nil
+	}
+
+	// Content can be a string or array of blocks
+	var text string
+	if err := json.Unmarshal(msg.Content, &text); err == nil && text != "" {
+		return []Step{{Type: "user", Content: text}}
+	}
+
+	// Array form: extract text blocks
+	var blocks []contentBlock
+	if err := json.Unmarshal(msg.Content, &blocks); err == nil {
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				return []Step{{Type: "user", Content: b.Text}}
+			}
+		}
+	}
+
+	return nil
 }
 
 func parseAssistantMessage(raw json.RawMessage) []Step {
@@ -369,10 +399,14 @@ func ParseJSONLLine(line []byte) []Step {
 	if err := json.Unmarshal(line, &entry); err != nil {
 		return nil
 	}
-	if entry.Type != "assistant" {
+	switch entry.Type {
+	case "user":
+		return parseUserMessage(entry.Message)
+	case "assistant":
+		return parseAssistantMessage(entry.Message)
+	default:
 		return nil
 	}
-	return parseAssistantMessage(entry.Message)
 }
 
 // TruncateThinking truncates thinking text to maxLen chars for display.

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -66,7 +66,7 @@ func TestParseSessionJSONL(t *testing.T) {
 			"type": "user",
 			"message": map[string]interface{}{
 				"role": "user",
-				"content": "some user message — should be ignored",
+				"content": "some user message",
 			},
 		},
 	}
@@ -86,8 +86,8 @@ func TestParseSessionJSONL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(steps) != 6 {
-		t.Fatalf("got %d steps, want 6", len(steps))
+	if len(steps) != 7 {
+		t.Fatalf("got %d steps, want 7", len(steps))
 	}
 
 	// thinking
@@ -121,6 +121,11 @@ func TestParseSessionJSONL(t *testing.T) {
 	// Skill
 	if steps[5].Type != "skill" || steps[5].Skill != "open-source-cto" {
 		t.Errorf("step 5 = %+v, want skill open-source-cto", steps[5])
+	}
+
+	// User message
+	if steps[6].Type != "user" || steps[6].Content != "some user message" {
+		t.Errorf("step 6 = %+v, want user 'some user message'", steps[6])
 	}
 }
 
@@ -160,13 +165,14 @@ func TestParseJSONLLine(t *testing.T) {
 		t.Errorf("ParseJSONLLine(assistant) = %+v, want [Read main.go]", steps)
 	}
 
-	// User message — should return nil
+	// User message — should return a user step
 	userLine, _ := json.Marshal(map[string]interface{}{
 		"type":    "user",
 		"message": map[string]interface{}{"role": "user", "content": "hello"},
 	})
-	if steps := ParseJSONLLine(userLine); steps != nil {
-		t.Errorf("ParseJSONLLine(user) = %+v, want nil", steps)
+	userSteps := ParseJSONLLine(userLine)
+	if len(userSteps) != 1 || userSteps[0].Type != "user" || userSteps[0].Content != "hello" {
+		t.Errorf("ParseJSONLLine(user) = %+v, want [user 'hello']", userSteps)
 	}
 
 	// Invalid JSON — should return nil

--- a/internal/tail/tail_test.go
+++ b/internal/tail/tail_test.go
@@ -107,7 +107,7 @@ func TestReadNewLines_PrependPartialBuffer(t *testing.T) {
 	}
 }
 
-func TestReadNewLines_SkipsNonAssistant(t *testing.T) {
+func TestReadNewLines_IncludesUserMessage(t *testing.T) {
 	path := tempJSONLPath(t)
 
 	userLine := marshalJSON(map[string]interface{}{
@@ -119,8 +119,31 @@ func TestReadNewLines_SkipsNonAssistant(t *testing.T) {
 	os.WriteFile(path, []byte(userLine+"\n"+assistLine+"\n"), 0644)
 
 	steps, _, _ := readNewLines(path, 0, nil)
+	if len(steps) != 2 {
+		t.Fatalf("got %d steps, want 2", len(steps))
+	}
+	if steps[0].Type != "user" || steps[0].Content != "hello" {
+		t.Errorf("step 0 = %+v, want user 'hello'", steps[0])
+	}
+	if steps[1].Tool != "Read" {
+		t.Errorf("step 1 = %+v, want Read", steps[1])
+	}
+}
+
+func TestReadNewLines_SkipsNonMessageTypes(t *testing.T) {
+	path := tempJSONLPath(t)
+
+	systemLine := marshalJSON(map[string]interface{}{
+		"type":    "system",
+		"message": map[string]interface{}{"role": "system", "content": "system prompt"},
+	})
+	assistLine := marshalJSON(assistantMsg("Read", map[string]string{"file_path": "x.go"}))
+
+	os.WriteFile(path, []byte(systemLine+"\n"+assistLine+"\n"), 0644)
+
+	steps, _, _ := readNewLines(path, 0, nil)
 	if len(steps) != 1 {
-		t.Fatalf("got %d steps, want 1 (user message should be skipped)", len(steps))
+		t.Fatalf("got %d steps, want 1 (system message should be skipped)", len(steps))
 	}
 	if steps[0].Tool != "Read" {
 		t.Errorf("step 0 = %+v, want Read", steps[0])


### PR DESCRIPTION
## Summary
- `toc runtime watch` and `toc runtime replay` were not showing the initial user message because `ParseJSONLLine` and `parseSessionJSONLFull` only processed `"assistant"` type JSONL entries
- Added parsing of `"user"` type entries into a new `"user"` step type with a `parseUserMessage` function that handles both string and array content formats
- Renders user messages as `[user] <prompt text>` in green in terminal output

## Test plan
- [x] All existing tests pass
- [x] Updated `TestParseSessionJSONL` to expect 7 steps (including user message) instead of 6
- [x] Updated `TestParseJSONLLine` to verify user messages return a user step instead of nil
- [x] Replaced `TestReadNewLines_SkipsNonAssistant` with `TestReadNewLines_IncludesUserMessage` and `TestReadNewLines_SkipsNonMessageTypes`
- [ ] Manual test: run `toc runtime spawn <agent> --prompt "test"` then `toc runtime watch <id>` and verify the initial `[user]` line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)