### PR TITLE
Switch Slack to user tokens (xoxp) via OAuth2

### DIFF
--- a/cmd/integrate_add.go
+++ b/cmd/integrate_add.go
@@ -15,6 +15,7 @@ import (
 )
 
 func init() {
+	integrateAddCmd.Flags().Bool("manual", false, "Manually paste the authorization code instead of using a local callback server")
 	integrateCmd.AddCommand(integrateAddCmd)
 }
 
@@ -79,8 +80,9 @@ var integrateAddCmd = &cobra.Command{
 			cred = &integration.Credential{AccessToken: token}
 
 		case "oauth2":
+			manual, _ := cmd.Flags().GetBool("manual")
 			var err error
-			cred, err = runOAuth2Flow(name, def)
+			cred, err = runOAuth2Flow(name, def, manual)
 			if err != nil {
 				return err
 			}
@@ -107,7 +109,7 @@ var integrateAddCmd = &cobra.Command{
 	},
 }
 
-func runOAuth2Flow(name string, def *integration.Definition) (*integration.Credential, error) {
+func runOAuth2Flow(name string, def *integration.Definition, manual bool) (*integration.Credential, error) {
 	ui.Info("This integration uses OAuth2. You'll need your app's Client ID and Client Secret.")
 	if def.Auth.SetupURL != "" {
 		ui.Info("Create an app at: %s", ui.Cyan(def.Auth.SetupURL))
@@ -143,24 +145,23 @@ func runOAuth2Flow(name string, def *integration.Definition) (*integration.Crede
 		return &integration.Credential{AccessToken: token}, nil
 	}
 
-	oauth2Cfg := integration.SlackOAuth2Config(clientID, clientSecret, def.Auth.RequiredScopes)
+	oauth2Cfg := integration.SlackOAuth2Config(clientID, clientSecret, def.Auth.RequiredScopes, def.Auth.UserScopes)
 
 	authURL := oauth2Cfg.AuthorizationURL()
 	fmt.Println()
-	ui.Info("Opening browser for authorization...")
-	ui.Info("If the browser doesn't open, visit: %s", ui.Cyan(authURL))
-	fmt.Println()
 
-	// Open browser
-	openBrowser(authURL)
+	// Store client credentials for future token refresh
+	clientCfg := &integration.OAuth2ClientConfig{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}
 
-	// Start callback server with 5-minute timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	ui.Info("Waiting for OAuth callback on localhost:%d...", oauth2Cfg.RedirectPort)
-
-	code, err := oauth2Cfg.RunCallbackServer(ctx)
+	var code string
+	if manual {
+		code, err = runManualOAuth2Flow(authURL)
+	} else {
+		code, err = runAutoOAuth2Flow(oauth2Cfg, authURL)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("OAuth2 authorization failed: %w", err)
 	}
@@ -172,16 +173,47 @@ func runOAuth2Flow(name string, def *integration.Definition) (*integration.Crede
 		return nil, fmt.Errorf("token exchange failed: %w", err)
 	}
 
-	// Store client credentials separately for future token refresh
-	clientCfg := &integration.OAuth2ClientConfig{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-	}
 	if err := integration.StoreOAuth2ClientConfig(name, clientCfg); err != nil {
 		ui.Warn("Could not store client info for token refresh: %s", err)
 	}
 
 	return cred, nil
+}
+
+// runAutoOAuth2Flow opens the browser and waits for the localhost callback.
+func runAutoOAuth2Flow(oauth2Cfg *integration.OAuth2Config, authURL string) (string, error) {
+	ui.Info("Opening browser for authorization...")
+	ui.Info("If the browser doesn't open, visit: %s", ui.Cyan(authURL))
+	fmt.Println()
+	ui.Info("Tip: If localhost callback fails (e.g. remote/SSH session), re-run with %s", ui.Bold("--manual"))
+	fmt.Println()
+
+	openBrowser(authURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ui.Info("Waiting for OAuth callback on localhost:%d...", oauth2Cfg.RedirectPort)
+
+	return oauth2Cfg.RunCallbackServer(ctx)
+}
+
+// runManualOAuth2Flow displays the auth URL and prompts the user to paste the callback URL or code.
+func runManualOAuth2Flow(authURL string) (string, error) {
+	ui.Info("Open this URL in your browser to authorize:")
+	fmt.Println()
+	fmt.Println("  " + authURL)
+	fmt.Println()
+	ui.Info("After authorizing, Slack will redirect to a localhost URL.")
+	ui.Info("Copy the full URL from the browser address bar (or just the code) and paste it below.")
+	fmt.Println()
+
+	raw, err := ui.Prompt("Paste callback URL or authorization code", "")
+	if err != nil {
+		return "", err
+	}
+
+	return integration.ParseCodeFromURL(raw)
 }
 
 func openBrowser(url string) {

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -26,6 +26,7 @@ type AuthConfig struct {
 	Method            string   `yaml:"method"` // oauth2, api_key, token
 	SetupURL          string   `yaml:"setup_url,omitempty"`
 	RequiredScopes    []string `yaml:"required_scopes,omitempty"`
+	UserScopes        []string `yaml:"user_scopes,omitempty"`
 	SetupInstructions string   `yaml:"setup_instructions,omitempty"`
 }
 

--- a/internal/integration/oauth2.go
+++ b/internal/integration/oauth2.go
@@ -18,11 +18,13 @@ type OAuth2Config struct {
 	ClientSecret string
 	AuthURL      string
 	TokenURL     string
-	Scopes       []string
+	Scopes       []string // bot scopes — sent as "scope" param
+	UserScopes   []string // user scopes — sent as "user_scope" param (Slack user tokens)
 	RedirectPort int
 }
 
 // OAuth2TokenResponse represents the response from a token exchange.
+// For Slack V2 OAuth, user tokens are nested under authed_user.
 type OAuth2TokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
@@ -31,26 +33,46 @@ type OAuth2TokenResponse struct {
 	Scope        string `json:"scope"`
 	OK           bool   `json:"ok"`
 	Error        string `json:"error"`
+	AuthedUser   *struct {
+		ID          string `json:"id"`
+		Scope       string `json:"scope"`
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	} `json:"authed_user,omitempty"`
 }
 
 // SlackOAuth2Config returns a pre-configured OAuth2Config for Slack.
-func SlackOAuth2Config(clientID, clientSecret string, scopes []string) *OAuth2Config {
+// When userScopes is non-empty, the flow requests user tokens (xoxp) via user_scope.
+// When scopes is non-empty, bot tokens (xoxb) are also requested via scope.
+func SlackOAuth2Config(clientID, clientSecret string, scopes, userScopes []string) *OAuth2Config {
 	return &OAuth2Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		AuthURL:      "https://slack.com/oauth/v2/authorize",
 		TokenURL:     "https://slack.com/api/oauth.v2.access",
 		Scopes:       scopes,
+		UserScopes:   userScopes,
 		RedirectPort: 8976,
 	}
 }
 
+// RedirectURI returns the localhost callback URI for this config.
+func (c *OAuth2Config) RedirectURI() string {
+	return fmt.Sprintf("http://localhost:%d/callback", c.RedirectPort)
+}
+
 // AuthorizationURL builds the URL to redirect the user to for OAuth consent.
+// For Slack user tokens, scopes are sent as "user_scope" (comma-separated).
 func (c *OAuth2Config) AuthorizationURL() string {
 	params := url.Values{
 		"client_id":    {c.ClientID},
-		"scope":        {strings.Join(c.Scopes, " ")},
-		"redirect_uri": {fmt.Sprintf("http://localhost:%d/callback", c.RedirectPort)},
+		"redirect_uri": {c.RedirectURI()},
+	}
+	if len(c.Scopes) > 0 {
+		params.Set("scope", strings.Join(c.Scopes, ","))
+	}
+	if len(c.UserScopes) > 0 {
+		params.Set("user_scope", strings.Join(c.UserScopes, ","))
 	}
 	return c.AuthURL + "?" + params.Encode()
 }
@@ -104,12 +126,14 @@ func (c *OAuth2Config) RunCallbackServer(ctx context.Context) (string, error) {
 }
 
 // ExchangeCode exchanges an authorization code for access and refresh tokens.
+// For Slack, when UserScopes were requested, the user token is extracted from
+// the authed_user field in the response.
 func (c *OAuth2Config) ExchangeCode(code string) (*Credential, error) {
 	data := url.Values{
 		"client_id":     {c.ClientID},
 		"client_secret": {c.ClientSecret},
 		"code":          {code},
-		"redirect_uri":  {fmt.Sprintf("http://localhost:%d/callback", c.RedirectPort)},
+		"redirect_uri":  {c.RedirectURI()},
 	}
 
 	resp, err := http.PostForm(c.TokenURL, data)
@@ -132,8 +156,18 @@ func (c *OAuth2Config) ExchangeCode(code string) (*Credential, error) {
 		return nil, fmt.Errorf("token exchange failed: %s", tokenResp.Error)
 	}
 
+	// Prefer user token from authed_user when user_scopes were requested.
+	accessToken := tokenResp.AccessToken
+	if len(c.UserScopes) > 0 && tokenResp.AuthedUser != nil && tokenResp.AuthedUser.AccessToken != "" {
+		accessToken = tokenResp.AuthedUser.AccessToken
+	}
+
+	if accessToken == "" {
+		return nil, fmt.Errorf("token exchange returned empty access token")
+	}
+
 	cred := &Credential{
-		AccessToken:  tokenResp.AccessToken,
+		AccessToken:  accessToken,
 		RefreshToken: tokenResp.RefreshToken,
 	}
 
@@ -143,6 +177,34 @@ func (c *OAuth2Config) ExchangeCode(code string) (*Credential, error) {
 	}
 
 	return cred, nil
+}
+
+// ParseCodeFromURL extracts the authorization code from a callback URL.
+// Accepts either a full URL (http://localhost:8976/callback?code=xyz) or a bare code string.
+func ParseCodeFromURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty input")
+	}
+
+	// If it looks like a URL, parse the code param
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", fmt.Errorf("invalid URL: %w", err)
+		}
+		if errMsg := u.Query().Get("error"); errMsg != "" {
+			return "", fmt.Errorf("OAuth error: %s — %s", errMsg, u.Query().Get("error_description"))
+		}
+		code := u.Query().Get("code")
+		if code == "" {
+			return "", fmt.Errorf("no authorization code found in URL")
+		}
+		return code, nil
+	}
+
+	// Otherwise treat the whole string as the code
+	return raw, nil
 }
 
 // RefreshAccessToken uses a refresh token to obtain a new access token.

--- a/internal/integration/oauth2_test.go
+++ b/internal/integration/oauth2_test.go
@@ -48,7 +48,7 @@ func TestIsExpired(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cred := &Credential{
-				AccessToken: "xoxb-test",
+				AccessToken: "xoxp-test",
 				ExpiresAt:   tt.expiresAt,
 			}
 			got := cred.IsExpired(tt.grace)
@@ -59,8 +59,8 @@ func TestIsExpired(t *testing.T) {
 	}
 }
 
-func TestSlackOAuth2Config_AuthorizationURL(t *testing.T) {
-	cfg := SlackOAuth2Config("client123", "secret456", []string{"channels:read", "chat:write"})
+func TestSlackOAuth2Config_AuthorizationURL_UserScopes(t *testing.T) {
+	cfg := SlackOAuth2Config("client123", "secret456", nil, []string{"channels:read", "chat:write", "search:read"})
 
 	url := cfg.AuthorizationURL()
 
@@ -68,11 +68,10 @@ func TestSlackOAuth2Config_AuthorizationURL(t *testing.T) {
 		t.Fatal("AuthorizationURL() returned empty string")
 	}
 
-	// Check that it contains the expected components
 	checks := []string{
 		"https://slack.com/oauth/v2/authorize",
 		"client_id=client123",
-		"scope=channels%3Aread+chat%3Awrite",
+		"user_scope=channels%3Aread%2Cchat%3Awrite%2Csearch%3Aread",
 		"redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Fcallback",
 	}
 
@@ -80,6 +79,83 @@ func TestSlackOAuth2Config_AuthorizationURL(t *testing.T) {
 		if !strings.Contains(url, check) {
 			t.Errorf("AuthorizationURL() missing %q\ngot: %s", check, url)
 		}
+	}
+
+	// Should NOT contain a bare "scope=" param (not "user_scope=") when only user_scopes are set
+	// Split on & and check each param individually
+	for _, part := range strings.Split(strings.SplitN(url, "?", 2)[1], "&") {
+		if strings.HasPrefix(part, "scope=") {
+			t.Errorf("AuthorizationURL() should not contain bot scope param when only user_scopes set\ngot param: %s\nfull url: %s", part, url)
+		}
+	}
+}
+
+func TestSlackOAuth2Config_AuthorizationURL_BothScopes(t *testing.T) {
+	cfg := SlackOAuth2Config("client123", "secret456",
+		[]string{"commands"},
+		[]string{"channels:read", "chat:write"},
+	)
+
+	url := cfg.AuthorizationURL()
+
+	if !strings.Contains(url, "scope=commands") {
+		t.Errorf("AuthorizationURL() missing bot scope param\ngot: %s", url)
+	}
+	if !strings.Contains(url, "user_scope=channels%3Aread%2Cchat%3Awrite") {
+		t.Errorf("AuthorizationURL() missing user_scope param\ngot: %s", url)
+	}
+}
+
+func TestParseCodeFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "full callback URL",
+			input: "http://localhost:8976/callback?code=abc123&state=xyz",
+			want:  "abc123",
+		},
+		{
+			name:  "bare code string",
+			input: "abc123",
+			want:  "abc123",
+		},
+		{
+			name:  "bare code with whitespace",
+			input: "  abc123  ",
+			want:  "abc123",
+		},
+		{
+			name:    "URL with error",
+			input:   "http://localhost:8976/callback?error=access_denied&error_description=user+denied",
+			wantErr: true,
+		},
+		{
+			name:    "URL without code param",
+			input:   "http://localhost:8976/callback?state=xyz",
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCodeFromURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseCodeFromURL(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseCodeFromURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/registry/integrations/slack/integration.yaml
+++ b/registry/integrations/slack/integration.yaml
@@ -1,24 +1,25 @@
 name: slack
-description: Slack API — messaging, channels, and reactions
+description: Slack API — messaging, channels, reactions, and search (user token)
 auth:
-  method: token
+  method: oauth2
   setup_url: https://api.slack.com/apps
-  required_scopes:
+  user_scopes:
     - channels:read
     - channels:history
     - chat:write
     - reactions:write
+    - search:read
   setup_instructions: |
     1. Go to https://api.slack.com/apps and sign in
     2. Click "Create New App" → "From scratch" (or select an existing app)
     3. Go to "OAuth & Permissions" in the sidebar
-    4. Under "Bot Token Scopes", add: channels:read, channels:history, chat:write, reactions:write
-    5. Click "Install to Workspace" and authorize the app
-    6. Copy the "Bot User OAuth Token" (starts with xoxb-)
+    4. Under "Redirect URLs", add: http://localhost:8976/callback
+    5. Note your Client ID and Client Secret from "Basic Information"
+    6. Run `toc integrate add slack` and paste them when prompted
 
 actions:
   send_message:
-    description: Send a message to a channel or DM
+    description: Send a message to a channel or DM (posted as you, not a bot)
     scopes:
       "*": any channel or DM
       dm: direct messages only
@@ -64,6 +65,37 @@ actions:
       - messages[].user
       - messages[].ts
       - messages[].type
+
+  search_messages:
+    description: Search messages across all channels the user has access to
+    scopes:
+      "*": all accessible channels
+    params:
+      - name: query
+        required: true
+      - name: count
+        required: false
+        default: "20"
+      - name: sort
+        required: false
+        default: timestamp
+      - name: sort_dir
+        required: false
+        default: desc
+    method: GET
+    endpoint: https://slack.com/api/search.messages
+    auth_header: "Bearer {{token}}"
+    body_format: query
+    rate_limit:
+      max: 20
+      window: 60s
+    returns:
+      - ok
+      - messages.total
+      - messages.matches[].text
+      - messages.matches[].username
+      - messages.matches[].ts
+      - messages.matches[].channel.name
 
   list_channels:
     description: List public channels in the workspace


### PR DESCRIPTION
## Summary
- **Switches Slack from bot tokens (xoxb) to user tokens (xoxp)** — messages post as the user (name, avatar, no APP badge) and unlocks `search.messages` which bots can't access
- **Adds `search_messages` action** to the Slack integration definition
- **Adds `--manual` flag** to `toc integrate add` for environments where the localhost callback server can't receive redirects (SSH sessions, remote containers, etc.)

## HTTPS redirect URI analysis

Researched five approaches to the Slack HTTPS redirect requirement:

1. **HTTPS-to-localhost redirect chain** — viable but adds hosted infrastructure dependency
2. **Manual code paste** — works everywhere, no infra needed
3. **Local HTTPS with mkcert** — too complex, platform-specific CA trust issues
4. **OOB redirect (`urn:ietf:wg:oauth:2.0:oob`)** — Slack doesn't support it
5. **localhost exception** — Slack (like Google and GitHub) explicitly allows `http://localhost` as a redirect URI for development/CLI apps

**Decision**: Use `http://localhost:8976/callback` directly (Slack allows it). Add `--manual` as a fallback where users paste the callback URL or authorization code — handles SSH, remote, and edge cases with zero infrastructure. This matches how `gcloud auth login` and `gh auth login --web` solve the same problem.

## Changes

| File | What changed |
|------|-------------|
| `registry/integrations/slack/integration.yaml` | `auth.method: oauth2`, `user_scopes` instead of bot scopes, new `search_messages` action, updated setup instructions |
| `internal/integration/integration.go` | Added `UserScopes` field to `AuthConfig` |
| `internal/integration/oauth2.go` | `user_scope` param in auth URL, parse `authed_user.access_token` from Slack V2 response, new `ParseCodeFromURL` helper, `RedirectURI()` method |
| `cmd/integrate_add.go` | `--manual` flag, split flow into `runAutoOAuth2Flow` / `runManualOAuth2Flow`, pass both bot and user scopes |
| `internal/integration/oauth2_test.go` | Tests for user_scope URL generation, both-scopes case, `ParseCodeFromURL` with URLs/bare codes/errors |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [ ] Manual test: `toc integrate add slack` with a real Slack app (auto flow)
- [ ] Manual test: `toc integrate add slack --manual` (paste flow)
- [ ] Verify user token (xoxp-) is stored, not bot token (xoxb-)
- [ ] Test `search_messages` action with user token

🤖 Generated with [Claude Code](https://claude.com/claude-code)