### PR TITLE
Fix word-deletion (Ctrl+Backspace) in interactive prompts

### DIFF
--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -98,6 +98,7 @@ var agentCreateCmd = &cobra.Command{
 			),
 		)
 
+		basics.WithProgramOptions(ui.FormOptions()...)
 		if err := basics.Run(); err != nil {
 			return err
 		}

--- a/cmd/agent_skills.go
+++ b/cmd/agent_skills.go
@@ -73,6 +73,7 @@ var agentSkillsCmd = &cobra.Command{
 			),
 		)
 
+		form.WithProgramOptions(ui.FormOptions()...)
 		if err := form.Run(); err != nil {
 			return err
 		}

--- a/cmd/skill_create.go
+++ b/cmd/skill_create.go
@@ -70,6 +70,7 @@ var skillCreateCmd = &cobra.Command{
 			),
 		)
 
+		form.WithProgramOptions(ui.FormOptions()...)
 		if err := form.Run(); err != nil {
 			return err
 		}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,8 +2,10 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
 	"github.com/fatih/color"
 )
@@ -18,8 +20,38 @@ var (
 	BoldCyan = color.New(color.Bold, color.FgCyan).SprintFunc()
 )
 
+// WordDeleteFilter remaps ctrl+backspace to ctrl+w so that the bubbles
+// textinput recognises it as word-deletion. BubbleTea v2 enables the Kitty
+// keyboard protocol, which sends a distinct ctrl+backspace event, but the
+// textinput default keymap only binds "alt+backspace" and "ctrl+w".
+func WordDeleteFilter(_ tea.Model, msg tea.Msg) tea.Msg {
+	if k, ok := msg.(tea.KeyPressMsg); ok {
+		if k.Code == tea.KeyBackspace && k.Mod == tea.ModCtrl {
+			return tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl}
+		}
+	}
+	return msg
+}
+
+// FormOptions returns the default tea.ProgramOption set that should be passed
+// to any huh form via WithProgramOptions. It includes the word-delete filter
+// and the stderr output that huh uses by default.
+func FormOptions() []tea.ProgramOption {
+	return []tea.ProgramOption{
+		tea.WithOutput(os.Stderr),
+		tea.WithFilter(WordDeleteFilter),
+	}
+}
+
+// runField wraps a single huh field in a form with our standard program options.
+func runField(field huh.Field) error {
+	return huh.NewForm(huh.NewGroup(field)).
+		WithShowHelp(false).
+		WithProgramOptions(FormOptions()...).
+		Run()
+}
+
 // Prompt asks for text input with an optional default value.
-// Uses Huh for proper line-editing support (word deletion, cursor movement).
 func Prompt(label, defaultVal string) (string, error) {
 	var val string
 	input := huh.NewInput().
@@ -28,7 +60,7 @@ func Prompt(label, defaultVal string) (string, error) {
 	if defaultVal != "" {
 		input = input.Description("default: " + defaultVal)
 	}
-	if err := input.Run(); err != nil {
+	if err := runField(input); err != nil {
 		return "", err
 	}
 	val = strings.TrimSpace(val)
@@ -44,7 +76,7 @@ func Confirm(label string, defaultVal bool) (bool, error) {
 	c := huh.NewConfirm().
 		Title(label).
 		Value(&result)
-	if err := c.Run(); err != nil {
+	if err := runField(c); err != nil {
 		return false, err
 	}
 	return result, nil
@@ -73,7 +105,7 @@ func Select(label string, options []SelectOption, defaultIdx int) (string, error
 		result = options[defaultIdx].Value
 	}
 
-	if err := sel.Run(); err != nil {
+	if err := runField(sel); err != nil {
 		return "", err
 	}
 	return result, nil

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,126 @@
+package ui_test
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/tiny-oc/toc/internal/ui"
+)
+
+func TestWordDeleteFilterRemapsCtrlBackspace(t *testing.T) {
+	// Ctrl+Backspace in Kitty protocol produces {Code: KeyBackspace, Mod: ModCtrl}.
+	// The WordDeleteFilter should remap it to ctrl+w so that the textinput
+	// recognises it as word deletion.
+	orig := tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModCtrl}
+	result := ui.WordDeleteFilter(nil, orig)
+
+	remapped, ok := result.(tea.KeyPressMsg)
+	if !ok {
+		t.Fatalf("expected KeyPressMsg, got %T", result)
+	}
+	if remapped.String() != "ctrl+w" {
+		t.Errorf("expected remapped key to be ctrl+w, got %q", remapped.String())
+	}
+
+	km := textinput.DefaultKeyMap()
+	if !key.Matches(remapped, km.DeleteWordBackward) {
+		t.Error("remapped key should match DeleteWordBackward")
+	}
+}
+
+func TestWordDeleteFilterPassthroughRegularBackspace(t *testing.T) {
+	// Regular backspace should NOT be remapped
+	orig := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	result := ui.WordDeleteFilter(nil, orig)
+
+	passed, ok := result.(tea.KeyPressMsg)
+	if !ok {
+		t.Fatalf("expected KeyPressMsg, got %T", result)
+	}
+	if passed.String() != "backspace" {
+		t.Errorf("regular backspace should pass through unchanged, got %q", passed.String())
+	}
+}
+
+func TestWordDeletionCtrlW(t *testing.T) {
+	m := textinput.New()
+	m.Focus()
+	m.SetValue("hello world foo")
+	m.SetCursor(15)
+
+	msg := tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl}
+	m, _ = m.Update(msg)
+
+	if got := m.Value(); got != "hello world " {
+		t.Errorf("after ctrl+w: got %q, want %q", got, "hello world ")
+	}
+}
+
+func TestWordDeletionAltBackspace(t *testing.T) {
+	m := textinput.New()
+	m.Focus()
+	m.SetValue("hello world foo")
+	m.SetCursor(15)
+
+	msg := tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModAlt}
+	m, _ = m.Update(msg)
+
+	if got := m.Value(); got != "hello world " {
+		t.Errorf("after alt+backspace: got %q, want %q", got, "hello world ")
+	}
+}
+
+func TestWordDeletionCtrlBackspaceViaFilter(t *testing.T) {
+	// End-to-end: Ctrl+Backspace → filter remaps to ctrl+w → textinput deletes word
+	m := textinput.New()
+	m.Focus()
+	m.SetValue("hello world foo")
+	m.SetCursor(15)
+
+	orig := tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModCtrl}
+	remapped := ui.WordDeleteFilter(nil, orig)
+	m, _ = m.Update(remapped)
+
+	if got := m.Value(); got != "hello world " {
+		t.Errorf("after ctrl+backspace via filter: got %q, want %q", got, "hello world ")
+	}
+}
+
+func TestKeyDecodingCtrlW(t *testing.T) {
+	var dec uv.EventDecoder
+	n, evt := dec.Decode([]byte{0x17})
+	if n != 1 {
+		t.Fatalf("expected 1 byte consumed, got %d", n)
+	}
+	kp, ok := evt.(uv.KeyPressEvent)
+	if !ok {
+		t.Fatalf("expected KeyPressEvent, got %T", evt)
+	}
+
+	km := textinput.DefaultKeyMap()
+	msg := tea.KeyPressMsg(kp)
+	if !key.Matches(msg, km.DeleteWordBackward) {
+		t.Errorf("ctrl+w byte (0x17) did not match DeleteWordBackward; key=%q", msg.String())
+	}
+}
+
+func TestKeyDecodingAltBackspace(t *testing.T) {
+	var dec uv.EventDecoder
+	n, evt := dec.Decode([]byte{0x1b, 0x7f})
+	if n != 2 {
+		t.Fatalf("expected 2 bytes consumed, got %d", n)
+	}
+	kp, ok := evt.(uv.KeyPressEvent)
+	if !ok {
+		t.Fatalf("expected KeyPressEvent, got %T", evt)
+	}
+
+	km := textinput.DefaultKeyMap()
+	msg := tea.KeyPressMsg(kp)
+	if !key.Matches(msg, km.DeleteWordBackward) {
+		t.Errorf("alt+backspace bytes (0x1b 0x7f) did not match DeleteWordBackward; key=%q", msg.String())
+	}
+}


### PR DESCRIPTION
## Summary

- BubbleTea v2 enables the Kitty keyboard protocol, which sends a distinct `ctrl+backspace` key event. The bubbles textinput only binds `alt+backspace` and `ctrl+w` for word deletion — not `ctrl+backspace`, so the key was silently dropped.
- Add a `tea.WithFilter` (`WordDeleteFilter`) that remaps `ctrl+backspace` → `ctrl+w` before the textinput sees it, enabling word deletion in Kitty-protocol terminals.
- Applied to all interactive prompts: `ui.Prompt`, `ui.Confirm`, `ui.Select`, and the direct `huh.NewForm` calls in `agent_create`, `skill_create`, and `agent_skills`.

## Key bindings after this fix

| Key combo | Terminal type | Behavior |
|-----------|-------------|----------|
| Ctrl+W | All | Word delete (already worked) |
| Option+Backspace | All (with meta key) | Word delete (already worked) |
| Ctrl+Backspace | Kitty protocol | Word delete (fixed) |
| Ctrl+Backspace | Legacy terminals | Single char delete (terminal limitation) |

## Test plan

- [x] New unit tests for `WordDeleteFilter` (remap + passthrough)
- [x] End-to-end test: ctrl+backspace → filter → textinput deletes word
- [x] Existing key decoding tests for ctrl+w and alt+backspace
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)