### PR TITLE
Add non-interactive flag support to all interactive CLI commands

### DIFF
--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"charm.land/huh/v2"
@@ -12,6 +13,15 @@ import (
 )
 
 func init() {
+	agentCreateCmd.Flags().String("name", "", "agent name (skip interactive prompt)")
+	agentCreateCmd.Flags().String("description", "", "agent description")
+	agentCreateCmd.Flags().String("model", "", "model: sonnet, opus, or haiku")
+	agentCreateCmd.Flags().StringSlice("skills", nil, "comma-separated skill names or URLs")
+	agentCreateCmd.Flags().StringSlice("context", nil, "comma-separated context sync patterns")
+	agentCreateCmd.Flags().String("instructions", "", "agent instructions (or @file to read from file)")
+	agentCreateCmd.Flags().StringSlice("compose", nil, "comma-separated compose file paths")
+	agentCreateCmd.Flags().StringSlice("sub-agents", nil, "comma-separated sub-agent names (or * for all)")
+	agentCreateCmd.Flags().String("on-end", "", "on-end hook prompt")
 	agentCmd.AddCommand(agentCreateCmd)
 }
 
@@ -23,11 +33,83 @@ var agentCreateCmd = &cobra.Command{
 			return err
 		}
 
+		name, _ := cmd.Flags().GetString("name")
+		desc, _ := cmd.Flags().GetString("description")
+		model, _ := cmd.Flags().GetString("model")
+		skills, _ := cmd.Flags().GetStringSlice("skills")
+		contextPatterns, _ := cmd.Flags().GetStringSlice("context")
+		instructionsFlag, _ := cmd.Flags().GetString("instructions")
+		compose, _ := cmd.Flags().GetStringSlice("compose")
+		subAgents, _ := cmd.Flags().GetStringSlice("sub-agents")
+		onEnd, _ := cmd.Flags().GetString("on-end")
+
+		// If --name is provided, run in non-interactive mode
+		if name != "" {
+			if model == "" {
+				model = "sonnet"
+			}
+			if err := agent.ValidateName(name); err != nil {
+				return err
+			}
+			if agent.Exists(name) {
+				return fmt.Errorf("agent '%s' already exists", name)
+			}
+
+			instructions := instructionsFlag
+			if strings.HasPrefix(instructions, "@") {
+				data, err := os.ReadFile(strings.TrimPrefix(instructions, "@"))
+				if err != nil {
+					return fmt.Errorf("failed to read instructions file: %w", err)
+				}
+				instructions = string(data)
+			}
+
+			var perms *agent.Permissions
+			if len(subAgents) > 0 {
+				perms = &agent.Permissions{
+					SubAgents: make(map[string]agent.PermissionLevel),
+				}
+				for _, sa := range subAgents {
+					perms.SubAgents[sa] = agent.PermOn
+				}
+			}
+
+			cfg := agent.AgentConfig{
+				Runtime:     "claude-code",
+				Name:        name,
+				Description: desc,
+				Model:       model,
+				Context:     contextPatterns,
+				Skills:      skills,
+				Perms:       perms,
+				OnEnd:       strings.TrimSpace(onEnd),
+				Compose:     compose,
+			}
+
+			agentMD := ""
+			if strings.TrimSpace(instructions) != "" {
+				agentMD = strings.TrimSpace(instructions)
+			}
+
+			if err := agent.CreateWithInstructions(cfg, agentMD); err != nil {
+				return err
+			}
+
+			auditLog("agent.create", map[string]interface{}{
+				"agent":   name,
+				"model":   model,
+				"runtime": "claude-code",
+			})
+
+			ui.Success("Created agent %s", ui.Bold(name))
+			return nil
+		}
+
+		// Interactive mode
 		ui.Header("Create a new agent")
 
-		var name, desc, model string
-		var contextRaw, skillsRaw, instructions string
-		var onEnd, composeRaw, subAgentsRaw string
+		var skillsRaw, contextRaw, instructions string
+		var composeRaw, subAgentsRaw string
 
 		basics := huh.NewForm(
 			huh.NewGroup(
@@ -117,10 +199,10 @@ var agentCreateCmd = &cobra.Command{
 			return result
 		}
 
-		contextPatterns := parseLines(contextRaw)
-		skills := parseLines(skillsRaw)
-		compose := parseLines(composeRaw)
-		subAgents := parseLines(subAgentsRaw)
+		contextPatterns = parseLines(contextRaw)
+		skills = parseLines(skillsRaw)
+		compose = parseLines(composeRaw)
+		subAgents = parseLines(subAgentsRaw)
 
 		var perms *agent.Permissions
 		if len(subAgents) > 0 {

--- a/cmd/agent_remove.go
+++ b/cmd/agent_remove.go
@@ -11,6 +11,7 @@ import (
 )
 
 func init() {
+	agentRemoveCmd.Flags().BoolP("force", "f", false, "skip confirmation prompt")
 	agentCmd.AddCommand(agentRemoveCmd)
 }
 
@@ -29,13 +30,16 @@ var agentRemoveCmd = &cobra.Command{
 			return fmt.Errorf("agent '%s' not found", name)
 		}
 
-		confirmed, err := ui.Confirm(fmt.Sprintf("Remove agent %s?", name), false)
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			ui.Info("Cancelled.")
-			return nil
+		force, _ := cmd.Flags().GetBool("force")
+		if !force {
+			confirmed, err := ui.Confirm(fmt.Sprintf("Remove agent %s?", name), false)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				ui.Info("Cancelled.")
+				return nil
+			}
 		}
 
 		if err := agent.Remove(name); err != nil {

--- a/cmd/agent_skills.go
+++ b/cmd/agent_skills.go
@@ -13,6 +13,7 @@ import (
 )
 
 func init() {
+	agentSkillsCmd.Flags().StringSlice("set", nil, "set skills directly (comma-separated, skip interactive prompt)")
 	agentCmd.AddCommand(agentSkillsCmd)
 }
 
@@ -32,6 +33,29 @@ var agentSkillsCmd = &cobra.Command{
 			return err
 		}
 
+		setFlag, _ := cmd.Flags().GetStringSlice("set")
+
+		// Non-interactive mode: --set flag provided
+		if cmd.Flags().Changed("set") {
+			cfg.Skills = setFlag
+			if err := agent.Save(cfg); err != nil {
+				return err
+			}
+
+			auditLog("agent.skills.update", map[string]interface{}{
+				"agent":  name,
+				"skills": strings.Join(setFlag, ", "),
+			})
+
+			if len(setFlag) == 0 {
+				ui.Success("Cleared all skills for %s", ui.Bold(name))
+			} else {
+				ui.Success("Updated skills for %s: %s", ui.Bold(name), ui.Dim(strings.Join(setFlag, ", ")))
+			}
+			return nil
+		}
+
+		// Interactive mode
 		// Build list of available skills (local + url refs)
 		locals, _ := skill.ListLocal()
 		reg, _ := skill.LoadRegistry()

--- a/cmd/integrate_add.go
+++ b/cmd/integrate_add.go
@@ -16,6 +16,10 @@ import (
 
 func init() {
 	integrateAddCmd.Flags().Bool("manual", false, "Manually paste the authorization code instead of using a local callback server")
+	integrateAddCmd.Flags().String("token", "", "Access token (skip interactive prompt)")
+	integrateAddCmd.Flags().String("client-id", "", "OAuth2 client ID (skip interactive prompt)")
+	integrateAddCmd.Flags().String("client-secret", "", "OAuth2 client secret (skip interactive prompt)")
+	integrateAddCmd.Flags().BoolP("force", "f", false, "Replace existing credentials without confirmation")
 	integrateCmd.AddCommand(integrateAddCmd)
 }
 
@@ -37,7 +41,8 @@ var integrateAddCmd = &cobra.Command{
 		}
 
 		// Check if already configured
-		if integration.CredentialExists(name) {
+		force, _ := cmd.Flags().GetBool("force")
+		if integration.CredentialExists(name) && !force {
 			replace, err := ui.Confirm(fmt.Sprintf("Integration '%s' already configured. Replace credentials?", name), false)
 			if err != nil || !replace {
 				return nil
@@ -57,22 +62,26 @@ var integrateAddCmd = &cobra.Command{
 
 		switch def.Auth.Method {
 		case "token", "api_key":
-			// Print setup instructions if available
-			if def.Auth.SetupInstructions != "" {
-				ui.Header("Setup instructions")
-				for _, line := range strings.Split(strings.TrimSpace(def.Auth.SetupInstructions), "\n") {
-					fmt.Println("  " + line)
+			token, _ := cmd.Flags().GetString("token")
+			if token == "" {
+				// Print setup instructions if available
+				if def.Auth.SetupInstructions != "" {
+					ui.Header("Setup instructions")
+					for _, line := range strings.Split(strings.TrimSpace(def.Auth.SetupInstructions), "\n") {
+						fmt.Println("  " + line)
+					}
+					fmt.Println()
 				}
-				fmt.Println()
-			}
-			if len(def.Auth.RequiredScopes) > 0 {
-				ui.Info("Required scopes: %s", ui.Bold(strings.Join(def.Auth.RequiredScopes, ", ")))
-				fmt.Println()
-			}
+				if len(def.Auth.RequiredScopes) > 0 {
+					ui.Info("Required scopes: %s", ui.Bold(strings.Join(def.Auth.RequiredScopes, ", ")))
+					fmt.Println()
+				}
 
-			token, err := ui.Prompt("Paste your access token", "")
-			if err != nil {
-				return err
+				var err error
+				token, err = ui.Prompt("Paste your access token", "")
+				if err != nil {
+					return err
+				}
 			}
 			if token == "" {
 				return fmt.Errorf("token cannot be empty")
@@ -81,8 +90,11 @@ var integrateAddCmd = &cobra.Command{
 
 		case "oauth2":
 			manual, _ := cmd.Flags().GetBool("manual")
+			flagClientID, _ := cmd.Flags().GetString("client-id")
+			flagClientSecret, _ := cmd.Flags().GetString("client-secret")
+			flagToken, _ := cmd.Flags().GetString("token")
 			var err error
-			cred, err = runOAuth2Flow(name, def, manual)
+			cred, err = runOAuth2Flow(name, def, manual, flagClientID, flagClientSecret, flagToken)
 			if err != nil {
 				return err
 			}
@@ -109,24 +121,35 @@ var integrateAddCmd = &cobra.Command{
 	},
 }
 
-func runOAuth2Flow(name string, def *integration.Definition, manual bool) (*integration.Credential, error) {
-	ui.Info("This integration uses OAuth2. You'll need your app's Client ID and Client Secret.")
-	if def.Auth.SetupURL != "" {
-		ui.Info("Create an app at: %s", ui.Cyan(def.Auth.SetupURL))
-	}
-	fmt.Println()
+func runOAuth2Flow(name string, def *integration.Definition, manual bool, flagClientID, flagClientSecret, flagToken string) (*integration.Credential, error) {
+	clientID := flagClientID
+	clientSecret := flagClientSecret
 
-	clientID, err := ui.Prompt("Enter Client ID", "")
-	if err != nil {
-		return nil, err
+	if clientID == "" || clientSecret == "" {
+		ui.Info("This integration uses OAuth2. You'll need your app's Client ID and Client Secret.")
+		if def.Auth.SetupURL != "" {
+			ui.Info("Create an app at: %s", ui.Cyan(def.Auth.SetupURL))
+		}
+		fmt.Println()
+	}
+
+	if clientID == "" {
+		var err error
+		clientID, err = ui.Prompt("Enter Client ID", "")
+		if err != nil {
+			return nil, err
+		}
 	}
 	if clientID == "" {
 		return nil, fmt.Errorf("client ID cannot be empty")
 	}
 
-	clientSecret, err := ui.Prompt("Enter Client Secret", "")
-	if err != nil {
-		return nil, err
+	if clientSecret == "" {
+		var err error
+		clientSecret, err = ui.Prompt("Enter Client Secret", "")
+		if err != nil {
+			return nil, err
+		}
 	}
 	if clientSecret == "" {
 		return nil, fmt.Errorf("client secret cannot be empty")
@@ -134,10 +157,14 @@ func runOAuth2Flow(name string, def *integration.Definition, manual bool) (*inte
 
 	// For non-slack integrations, fall back to PAT until we add provider-specific configs
 	if name != "slack" {
-		ui.Info("Generic OAuth2 flow — enter a personal access token instead.")
-		token, err := ui.Prompt("Enter access token", "")
-		if err != nil {
-			return nil, err
+		token := flagToken
+		if token == "" {
+			ui.Info("Generic OAuth2 flow — enter a personal access token instead.")
+			var err error
+			token, err = ui.Prompt("Enter access token", "")
+			if err != nil {
+				return nil, err
+			}
 		}
 		if token == "" {
 			return nil, fmt.Errorf("token cannot be empty")
@@ -157,13 +184,14 @@ func runOAuth2Flow(name string, def *integration.Definition, manual bool) (*inte
 	}
 
 	var code string
+	var codeErr error
 	if manual {
-		code, err = runManualOAuth2Flow(authURL)
+		code, codeErr = runManualOAuth2Flow(authURL)
 	} else {
-		code, err = runAutoOAuth2Flow(oauth2Cfg, authURL)
+		code, codeErr = runAutoOAuth2Flow(oauth2Cfg, authURL)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("OAuth2 authorization failed: %w", err)
+	if codeErr != nil {
+		return nil, fmt.Errorf("OAuth2 authorization failed: %w", codeErr)
 	}
 
 	ui.Info("Authorization code received, exchanging for tokens...")

--- a/cmd/integrate_remove.go
+++ b/cmd/integrate_remove.go
@@ -10,6 +10,7 @@ import (
 )
 
 func init() {
+	integrateRemoveCmd.Flags().BoolP("force", "f", false, "skip confirmation prompt")
 	integrateCmd.AddCommand(integrateRemoveCmd)
 }
 
@@ -28,9 +29,12 @@ var integrateRemoveCmd = &cobra.Command{
 			return fmt.Errorf("integration '%s' is not configured", name)
 		}
 
-		confirm, err := ui.Confirm(fmt.Sprintf("Remove integration '%s' and delete its credentials?", name), false)
-		if err != nil || !confirm {
-			return nil
+		force, _ := cmd.Flags().GetBool("force")
+		if !force {
+			confirm, err := ui.Confirm(fmt.Sprintf("Remove integration '%s' and delete its credentials?", name), false)
+			if err != nil || !confirm {
+				return nil
+			}
 		}
 
 		if err := integration.RemoveCredential(name); err != nil {

--- a/cmd/skill_create.go
+++ b/cmd/skill_create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"charm.land/huh/v2"
@@ -12,6 +13,9 @@ import (
 )
 
 func init() {
+	skillCreateCmd.Flags().String("name", "", "skill name (skip interactive prompt)")
+	skillCreateCmd.Flags().String("description", "", "skill description")
+	skillCreateCmd.Flags().String("instructions", "", "skill instructions (or @file to read from file)")
 	skillCmd.AddCommand(skillCreateCmd)
 }
 
@@ -23,9 +27,56 @@ var skillCreateCmd = &cobra.Command{
 			return err
 		}
 
+		name, _ := cmd.Flags().GetString("name")
+		description, _ := cmd.Flags().GetString("description")
+		instructionsFlag, _ := cmd.Flags().GetString("instructions")
+
+		// If --name is provided, run in non-interactive mode
+		if name != "" {
+			if err := skill.ValidateName(name); err != nil {
+				return err
+			}
+			if skill.Exists(name) {
+				return fmt.Errorf("skill '%s' already exists", name)
+			}
+			if description == "" {
+				return fmt.Errorf("--description is required in non-interactive mode")
+			}
+
+			instructions := instructionsFlag
+			if strings.HasPrefix(instructions, "@") {
+				data, err := os.ReadFile(strings.TrimPrefix(instructions, "@"))
+				if err != nil {
+					return fmt.Errorf("failed to read instructions file: %w", err)
+				}
+				instructions = string(data)
+			}
+
+			meta := skill.SkillMeta{
+				Name:        name,
+				Description: description,
+			}
+
+			body := ""
+			if strings.TrimSpace(instructions) != "" {
+				body = strings.TrimSpace(instructions)
+			}
+
+			if err := skill.CreateFromMeta(meta, body); err != nil {
+				return err
+			}
+
+			auditLog("skill.create", map[string]interface{}{
+				"skill": name,
+			})
+
+			ui.Success("Created skill %s", ui.Bold(name))
+			return nil
+		}
+
+		// Interactive mode
 		ui.Header("Create a new skill")
 
-		var name, description string
 		var instructions string
 
 		form := huh.NewForm(

--- a/cmd/skill_remove.go
+++ b/cmd/skill_remove.go
@@ -10,6 +10,7 @@ import (
 )
 
 func init() {
+	skillRemoveCmd.Flags().BoolP("force", "f", false, "skip confirmation prompt")
 	skillCmd.AddCommand(skillRemoveCmd)
 }
 
@@ -39,13 +40,16 @@ var skillRemoveCmd = &cobra.Command{
 			skillType = "url"
 		}
 
-		confirmed, err := ui.Confirm(fmt.Sprintf("Remove %s skill %s?", skillType, name), false)
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			ui.Info("Cancelled.")
-			return nil
+		force, _ := cmd.Flags().GetBool("force")
+		if !force {
+			confirmed, err := ui.Confirm(fmt.Sprintf("Remove %s skill %s?", skillType, name), false)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				ui.Info("Cancelled.")
+				return nil
+			}
 		}
 
 		if isLocal {


### PR DESCRIPTION
## Summary

- Every CLI command that required interactive prompts (huh forms, `ui.Prompt`, `ui.Confirm`) now supports full non-interactive usage via flags
- Interactive mode remains the default UX when flags are not provided
- Enables all `toc` commands to work in CI pipelines, scripts, and piped environments

## Commands fixed

| Command | New flags |
|---------|-----------|
| `toc agent create` | `--name`, `--model`, `--description`, `--skills`, `--context`, `--instructions` (supports `@file`), `--compose`, `--sub-agents`, `--on-end` |
| `toc skill create` | `--name`, `--description`, `--instructions` (supports `@file`) |
| `toc agent skills <name>` | `--set` (comma-separated skill list) |
| `toc agent remove` | `--force` / `-f` |
| `toc skill remove` | `--force` / `-f` |
| `toc integrate add` | `--token`, `--client-id`, `--client-secret`, `--force` / `-f` |
| `toc integrate remove` | `--force` / `-f` |

## Examples

```bash
# CI: create an agent without prompts
toc agent create --name pr-reviewer --model sonnet --description "Reviews PRs"

# CI: create a skill
toc skill create --name code-review --description "Reviews code" --instructions @instructions.md

# CI: set skills on an agent
toc agent skills my-agent --set code-review,deploy

# CI: add integration with token
toc integrate add github --token "$GITHUB_TOKEN" --force

# CI: remove without confirmation
toc agent remove old-agent --force
```

## Test plan

- [x] `go build ./...` passes
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: verify interactive mode still works for each command
- [ ] Manual: verify non-interactive mode works for each command

🤖 Generated with [Claude Code](https://claude.com/claude-code)