### PR TITLE
Use workers.dev domain for OAuth callback relay

### DIFF
--- a/internal/integration/oauth2.go
+++ b/internal/integration/oauth2.go
@@ -44,7 +44,7 @@ type OAuth2TokenResponse struct {
 
 // SlackOAuthCallbackURL is the hosted HTTPS endpoint that receives Slack OAuth
 // callbacks and displays the authorization code for the user to copy.
-const SlackOAuthCallbackURL = "https://toc.opencompany.cloud/slack/callback"
+const SlackOAuthCallbackURL = "https://square-paper-84df.dev-f64.workers.dev/slack/callback"
 
 // SlackOAuth2Config returns a pre-configured OAuth2Config for Slack.
 // When userScopes is non-empty, the flow requests user tokens (xoxp) via user_scope.

--- a/internal/integration/oauth2_test.go
+++ b/internal/integration/oauth2_test.go
@@ -72,7 +72,7 @@ func TestSlackOAuth2Config_AuthorizationURL_UserScopes(t *testing.T) {
 		"https://slack.com/oauth/v2/authorize",
 		"client_id=client123",
 		"user_scope=channels%3Aread%2Cchat%3Awrite%2Csearch%3Aread",
-		"redirect_uri=https%3A%2F%2Ftoc.opencompany.cloud%2Fslack%2Fcallback",
+		"redirect_uri=https%3A%2F%2Fsquare-paper-84df.dev-f64.workers.dev%2Fslack%2Fcallback",
 	}
 
 	for _, check := range checks {

--- a/registry/integrations/slack/integration.yaml
+++ b/registry/integrations/slack/integration.yaml
@@ -13,7 +13,7 @@ auth:
     1. Go to https://api.slack.com/apps and sign in
     2. Click "Create New App" → "From scratch" (or select an existing app)
     3. Go to "OAuth & Permissions" in the sidebar
-    4. Under "Redirect URLs", add: https://toc.opencompany.cloud/slack/callback
+    4. Under "Redirect URLs", add: https://square-paper-84df.dev-f64.workers.dev/slack/callback
     5. Note your Client ID and Client Secret from "Basic Information"
     6. Run `toc integrate add slack` and paste them when prompted
 

--- a/web/auth-callback/README.md
+++ b/web/auth-callback/README.md
@@ -8,7 +8,7 @@ Slack requires HTTPS redirect URIs. The CLI can only listen on localhost. This w
 
 ```
 Slack OAuth redirect
-  → https://toc.opencompany.cloud/slack/callback?code=xyz
+  → https://square-paper-84df.dev-f64.workers.dev/slack/callback?code=xyz
   → Worker 302 redirects to http://localhost:8976/callback?code=xyz
   → CLI's localhost server captures the code automatically
 ```
@@ -28,37 +28,17 @@ cd web/auth-callback
 npx wrangler deploy
 ```
 
-## One-time infrastructure setup
+## One-time setup
 
-These steps only need to be done once. After that, deployments are handled by CI.
-
-### 1. Cloudflare API token
+### Cloudflare API token
 
 1. Go to [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens)
-2. Create a token with **Workers Scripts: Edit** permission, scoped to the account that owns `opencompany.cloud`
+2. Create a token with **Workers Scripts: Edit** permission
 3. Add it as a GitHub repository secret named `CLOUDFLARE_API_TOKEN`
 
-### 2. DNS / Worker route for `toc.opencompany.cloud`
+### Slack app redirect URI
 
-The worker needs to be reachable at `https://toc.opencompany.cloud/slack/callback`. There are two options:
-
-**Option A: Custom domain (recommended)**
-
-1. In the Cloudflare dashboard, go to **Workers & Pages > toc-auth-callback > Settings > Domains & Routes**
-2. Add a custom domain: `toc.opencompany.cloud`
-3. Cloudflare automatically provisions the DNS record and TLS certificate
-
-**Option B: Worker route**
-
-1. In the Cloudflare dashboard, go to the **opencompany.cloud** zone > **Workers Routes**
-2. Add a route: `toc.opencompany.cloud/slack/*` → `toc-auth-callback`
-3. Ensure a DNS record exists for `toc.opencompany.cloud` (a proxied AAAA record to `100::` works as a placeholder)
-
-The route pattern in `wrangler.toml` must match whichever option you choose.
-
-### 3. Slack app redirect URI
-
-In your [Slack app settings](https://api.slack.com/apps), add `https://toc.opencompany.cloud/slack/callback` as an allowed redirect URI under **OAuth & Permissions**.
+In your [Slack app settings](https://api.slack.com/apps), add `https://square-paper-84df.dev-f64.workers.dev/slack/callback` as an allowed redirect URI under **OAuth & Permissions**.
 
 ## Local development
 


### PR DESCRIPTION
## Summary
- Replaces all `toc.opencompany.cloud` references with `square-paper-84df.dev-f64.workers.dev`
- Simplifies README — removes DNS/custom domain setup section (no longer needed)
- Updates Go code, tests, and Slack integration YAML

## Test plan
- [ ] Deploy worker workflow passes
- [ ] `toc integrate add slack` uses correct redirect URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)