### PR TITLE
Fix worker URL to use toc-auth-callback subdomain

### DIFF
--- a/internal/integration/oauth2.go
+++ b/internal/integration/oauth2.go
@@ -44,7 +44,7 @@ type OAuth2TokenResponse struct {
 
 // SlackOAuthCallbackURL is the hosted HTTPS endpoint that receives Slack OAuth
 // callbacks and displays the authorization code for the user to copy.
-const SlackOAuthCallbackURL = "https://square-paper-84df.dev-f64.workers.dev/slack/callback"
+const SlackOAuthCallbackURL = "https://toc-auth-callback.dev-f64.workers.dev/slack/callback"
 
 // SlackOAuth2Config returns a pre-configured OAuth2Config for Slack.
 // When userScopes is non-empty, the flow requests user tokens (xoxp) via user_scope.

--- a/internal/integration/oauth2_test.go
+++ b/internal/integration/oauth2_test.go
@@ -72,7 +72,7 @@ func TestSlackOAuth2Config_AuthorizationURL_UserScopes(t *testing.T) {
 		"https://slack.com/oauth/v2/authorize",
 		"client_id=client123",
 		"user_scope=channels%3Aread%2Cchat%3Awrite%2Csearch%3Aread",
-		"redirect_uri=https%3A%2F%2Fsquare-paper-84df.dev-f64.workers.dev%2Fslack%2Fcallback",
+		"redirect_uri=https%3A%2F%2Ftoc-auth-callback.dev-f64.workers.dev%2Fslack%2Fcallback",
 	}
 
 	for _, check := range checks {

--- a/registry/integrations/slack/integration.yaml
+++ b/registry/integrations/slack/integration.yaml
@@ -13,7 +13,7 @@ auth:
     1. Go to https://api.slack.com/apps and sign in
     2. Click "Create New App" → "From scratch" (or select an existing app)
     3. Go to "OAuth & Permissions" in the sidebar
-    4. Under "Redirect URLs", add: https://square-paper-84df.dev-f64.workers.dev/slack/callback
+    4. Under "Redirect URLs", add: https://toc-auth-callback.dev-f64.workers.dev/slack/callback
     5. Note your Client ID and Client Secret from "Basic Information"
     6. Run `toc integrate add slack` and paste them when prompted
 

--- a/web/auth-callback/README.md
+++ b/web/auth-callback/README.md
@@ -8,7 +8,7 @@ Slack requires HTTPS redirect URIs. The CLI can only listen on localhost. This w
 
 ```
 Slack OAuth redirect
-  → https://square-paper-84df.dev-f64.workers.dev/slack/callback?code=xyz
+  → https://toc-auth-callback.dev-f64.workers.dev/slack/callback?code=xyz
   → Worker 302 redirects to http://localhost:8976/callback?code=xyz
   → CLI's localhost server captures the code automatically
 ```
@@ -38,7 +38,7 @@ npx wrangler deploy
 
 ### Slack app redirect URI
 
-In your [Slack app settings](https://api.slack.com/apps), add `https://square-paper-84df.dev-f64.workers.dev/slack/callback` as an allowed redirect URI under **OAuth & Permissions**.
+In your [Slack app settings](https://api.slack.com/apps), add `https://toc-auth-callback.dev-f64.workers.dev/slack/callback` as an allowed redirect URI under **OAuth & Permissions**.
 
 ## Local development
 


### PR DESCRIPTION
## Summary
- Updates all references from `square-paper-84df.dev-f64.workers.dev` to `toc-auth-callback.dev-f64.workers.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)