### PR TITLE
Fix detached session resume using wrong CLI flag

### DIFF
--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -119,14 +119,13 @@ func (claudeProvider) LaunchDetached(opts DetachedOptions) error {
 // BuildClaudeDetachedScript builds the wrapper script for a detached Claude session.
 func BuildClaudeDetachedScript(opts DetachedOptions, promptPath string) string {
 	args := "claude --dangerously-skip-permissions"
-	if opts.Resume {
-		args += " --continue"
-	}
 	args += fmt.Sprintf(" -p \"$(cat %q)\"", promptPath)
 	if opts.Model != "" {
 		args += fmt.Sprintf(" --model %s", opts.Model)
 	}
-	if opts.SessionID != "" {
+	if opts.Resume && opts.SessionID != "" {
+		args += fmt.Sprintf(" --resume %s", opts.SessionID)
+	} else if opts.SessionID != "" {
 		args += fmt.Sprintf(" --session-id %s", opts.SessionID)
 	}
 

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -115,7 +115,7 @@ func TestBuildDetachedScript_WithoutModel(t *testing.T) {
 	}
 }
 
-func TestBuildDetachedScript_Resume_UsesContinueFlag(t *testing.T) {
+func TestBuildDetachedScript_Resume_UsesResumeFlag(t *testing.T) {
 	dir := t.TempDir()
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("resume prompt"), 0644)
@@ -126,8 +126,14 @@ func TestBuildDetachedScript_Resume_UsesContinueFlag(t *testing.T) {
 		Resume: true,
 	}, promptPath)
 
-	if !strings.Contains(script, "--continue") {
-		t.Error("resume script should use --continue flag")
+	if !strings.Contains(script, "--resume sess-789") {
+		t.Error("resume script should use --resume <session-id> flag")
+	}
+	if strings.Contains(script, "--continue") {
+		t.Error("resume script should not use --continue flag")
+	}
+	if strings.Contains(script, "--session-id") {
+		t.Error("resume script should not use --session-id (--resume already targets the session)")
 	}
 	if !strings.Contains(script, "echo $$ >") {
 		t.Error("resume script should write PID file")
@@ -137,7 +143,7 @@ func TestBuildDetachedScript_Resume_UsesContinueFlag(t *testing.T) {
 	}
 }
 
-func TestBuildDetachedScript_NoResume_NoContinueFlag(t *testing.T) {
+func TestBuildDetachedScript_NoResume_NoResumeFlag(t *testing.T) {
 	dir := t.TempDir()
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
@@ -150,6 +156,12 @@ func TestBuildDetachedScript_NoResume_NoContinueFlag(t *testing.T) {
 
 	if strings.Contains(script, "--continue") {
 		t.Error("non-resume script should not contain --continue flag")
+	}
+	if strings.Contains(script, "--resume") {
+		t.Error("non-resume script should not contain --resume flag")
+	}
+	if !strings.Contains(script, "--session-id sess") {
+		t.Error("non-resume script should use --session-id")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `BuildClaudeDetachedScript` was generating `--continue --session-id <id>` when resuming a detached sub-agent session. `--continue` resumes the most recent conversation in the CWD (not a specific session), and combined with `--session-id` it conflicts — causing Claude CLI to exit immediately with a non-zero code.
- The wrapper script captures that exit code, and `resolveSubAgentStatus()` reads it as `StatusCompletedError`, so the session shows as "failed" instantly after resume.
- Fix: use `--resume <session-id>` (matching what `LaunchInteractive` already does correctly), and omit `--session-id` since `--resume` implicitly targets the session.

## Test plan

- [x] Updated `TestBuildDetachedScript_Resume_UsesResumeFlag` to assert `--resume <id>` instead of `--continue`
- [x] Updated `TestBuildDetachedScript_NoResume_NoResumeFlag` to verify `--session-id` is used for non-resume
- [x] Full test suite passes (`go test -short ./...`)
- [ ] Manual: `toc runtime spawn <agent> --prompt "..."` → let it fail → `toc runtime spawn <agent> --resume <id>` → verify session completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)