### PR TITLE
Add Exa semantic search integration

### DIFF
--- a/cmd/integrate_test_cmd.go
+++ b/cmd/integrate_test_cmd.go
@@ -43,13 +43,13 @@ var integrateTestCmd = &cobra.Command{
 		ui.Info("Testing %s credentials...", ui.Bold(name))
 
 		// Use the first GET action as the test, or fall back to a known test endpoint
-		testURL, authHeader := getTestEndpoint(name, def, cred)
+		testURL, headerName, headerValue := getTestEndpoint(name, def, cred)
 
 		req, err := http.NewRequest("GET", testURL, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create test request: %w", err)
 		}
-		req.Header.Set("Authorization", authHeader)
+		req.Header.Set(headerName, headerValue)
 		req.Header.Set("User-Agent", "toc/1.0")
 
 		client := &http.Client{}
@@ -73,25 +73,36 @@ var integrateTestCmd = &cobra.Command{
 	},
 }
 
-func getTestEndpoint(name string, def *integration.Definition, cred *integration.Credential) (string, string) {
-	// Use well-known test endpoints per integration
+// getTestEndpoint returns the URL, header name, and header value for testing credentials.
+func getTestEndpoint(name string, def *integration.Definition, cred *integration.Credential) (string, string, string) {
 	switch name {
 	case "github":
-		authHeader := strings.ReplaceAll("Bearer {{token}}", "{{token}}", cred.AccessToken)
-		return "https://api.github.com/user", authHeader
+		return "https://api.github.com/user", "Authorization", "Bearer " + cred.AccessToken
 	case "slack":
-		authHeader := "Bearer " + cred.AccessToken
-		return "https://slack.com/api/auth.test", authHeader
+		return "https://slack.com/api/auth.test", "Authorization", "Bearer " + cred.AccessToken
+	case "exa":
+		return "https://api.exa.ai/search", "x-api-key", cred.AccessToken
 	default:
 		// Find the first GET action and use that
 		for _, action := range def.Actions {
 			if action.Method == "GET" {
-				authHeader := strings.ReplaceAll(action.AuthHeader, "{{token}}", cred.AccessToken)
-				return action.Endpoint, authHeader
+				headerName, headerValue := parseAuthHeader(action.AuthHeader, cred.AccessToken)
+				return action.Endpoint, headerName, headerValue
 			}
 		}
-		// Last resort
-		authHeader := strings.ReplaceAll("Bearer {{token}}", "{{token}}", cred.AccessToken)
-		return def.Auth.SetupURL, authHeader
+		return def.Auth.SetupURL, "Authorization", "Bearer " + cred.AccessToken
 	}
+}
+
+// parseAuthHeader splits an auth_header template into header name and value.
+// If the template contains ": ", the left side is the header name.
+// Otherwise, "Authorization" is used as the header name.
+func parseAuthHeader(template, token string) (string, string) {
+	if idx := strings.Index(template, ": "); idx > 0 {
+		name := template[:idx]
+		value := strings.ReplaceAll(template[idx+2:], "{{token}}", token)
+		return name, value
+	}
+	value := strings.ReplaceAll(template, "{{token}}", token)
+	return "Authorization", value
 }

--- a/e2e/integration_gateway_test.go
+++ b/e2e/integration_gateway_test.go
@@ -104,3 +104,140 @@ func TestSmoke_IntegrationGateway(t *testing.T) {
 		t.Error("admin.delete should be denied with items.*:* permission")
 	}
 }
+
+func TestSmoke_ExaIntegrationGateway(t *testing.T) {
+	// Start a fake Exa API server.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify x-api-key header (not Authorization).
+		if r.Header.Get("x-api-key") != "exa-test-key-123" {
+			t.Errorf("expected x-api-key header 'exa-test-key-123', got: %q", r.Header.Get("x-api-key"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("expected no Authorization header for Exa, got: %q", r.Header.Get("Authorization"))
+		}
+
+		// Verify the request body is properly typed JSON.
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		// query should be a string
+		if body["query"] != "semantic search test" {
+			t.Errorf("expected query 'semantic search test', got: %v", body["query"])
+		}
+
+		// numResults should be a number (float64 from JSON)
+		if body["numResults"] != float64(3) {
+			t.Errorf("expected numResults 3, got: %v (%T)", body["numResults"], body["numResults"])
+		}
+
+		// contents should be a nested object with highlights: true
+		contents, ok := body["contents"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected contents to be object, got: %T", body["contents"])
+		}
+		if contents["highlights"] != true {
+			t.Errorf("expected contents.highlights true, got: %v", contents["highlights"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"requestId":  "req-123",
+			"searchType": "neural",
+			"results": []map[string]interface{}{
+				{
+					"title":         "Test Result",
+					"url":           "https://example.com/test",
+					"publishedDate": "2025-01-15",
+					"author":        "Test Author",
+					"highlights":    []string{"highlighted snippet"},
+					"score":         0.95,
+				},
+			},
+			"costDollars": map[string]interface{}{"total": 0.001},
+		})
+	}))
+	defer server.Close()
+
+	def := &integration.Definition{
+		Name:        "exa",
+		Description: "Exa API for e2e test",
+		Auth:        integration.AuthConfig{Method: "api_key"},
+		Actions: map[string]integration.Action{
+			"search": {
+				Description: "Semantic search",
+				Method:      "POST",
+				Endpoint:    server.URL + "/search",
+				AuthHeader:  "x-api-key: {{token}}",
+				BodyFormat:  "json",
+				Returns: []string{
+					"results[].title",
+					"results[].url",
+					"results[].publishedDate",
+					"results[].author",
+					"results[].highlights",
+				},
+			},
+		},
+	}
+
+	cred := &integration.Credential{
+		AccessToken: "exa-test-key-123",
+	}
+
+	resp, err := integration.Invoke(&integration.InvokeRequest{
+		SessionID:   "test-session-exa",
+		Integration: "exa",
+		Action:      "search",
+		Params: map[string]string{
+			"query":      "semantic search test",
+			"numResults": "3",
+		},
+		Credential: cred,
+		Definition: def,
+	})
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status 200, got: %d", resp.StatusCode)
+	}
+
+	// Verify response was filtered.
+	// The gateway's results[].field notation extracts per-field arrays into a nested map.
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map response, got: %T", resp.Data)
+	}
+
+	results, ok := data["results"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected results to be map (flattened by field), got: %T", data["results"])
+	}
+
+	// Each field should contain an array of extracted values.
+	titles, ok := results["title"].([]interface{})
+	if !ok || len(titles) != 1 || titles[0] != "Test Result" {
+		t.Errorf("expected results.title = ['Test Result'], got: %v", results["title"])
+	}
+	urls, ok := results["url"].([]interface{})
+	if !ok || len(urls) != 1 || urls[0] != "https://example.com/test" {
+		t.Errorf("expected results.url = ['https://example.com/test'], got: %v", results["url"])
+	}
+
+	// score should be filtered out (not in whitelist).
+	if _, ok := results["score"]; ok {
+		t.Error("score should have been filtered out")
+	}
+
+	// costDollars should be filtered out.
+	if _, ok := data["costDollars"]; ok {
+		t.Error("costDollars should have been filtered out")
+	}
+	// requestId should be filtered out.
+	if _, ok := data["requestId"]; ok {
+		t.Error("requestId should have been filtered out")
+	}
+}

--- a/internal/integration/exa.go
+++ b/internal/integration/exa.go
@@ -1,0 +1,81 @@
+package integration
+
+import (
+	"strconv"
+	"strings"
+)
+
+// BuildExaRequestBody transforms flat string params into the typed, nested JSON
+// structure that the Exa API expects. This handles:
+//   - Integer coercion for numResults
+//   - Boolean coercion for moderation
+//   - Comma-separated strings → arrays for includeDomains, excludeDomains,
+//     includeText, excludeText, and ids
+//   - Default contents.highlights injection for search/find_similar actions
+func BuildExaRequestBody(action string, params map[string]string) map[string]interface{} {
+	body := make(map[string]interface{})
+
+	// Integer params
+	intParams := map[string]bool{"numResults": true}
+	// Array params (comma-separated → []string)
+	arrayParams := map[string]bool{
+		"includeDomains": true,
+		"excludeDomains": true,
+		"includeText":    true,
+		"excludeText":    true,
+		"ids":            true,
+	}
+	// Boolean params
+	boolParams := map[string]bool{"moderation": true}
+
+	for k, v := range params {
+		switch {
+		case intParams[k]:
+			if n, err := strconv.Atoi(v); err == nil {
+				body[k] = n
+			} else {
+				body[k] = v
+			}
+		case arrayParams[k]:
+			body[k] = splitCSV(v)
+		case boolParams[k]:
+			body[k] = v == "true"
+		default:
+			body[k] = v
+		}
+	}
+
+	// Inject default contents.highlights for search and find_similar
+	// unless the caller already set contents explicitly.
+	if action == "search" || action == "find_similar" {
+		if _, hasContents := body["contents"]; !hasContents {
+			body["contents"] = map[string]interface{}{
+				"highlights": true,
+			}
+		}
+	}
+
+	// Inject default contents.text for get_contents
+	if action == "get_contents" {
+		if _, hasContents := body["contents"]; !hasContents {
+			body["contents"] = map[string]interface{}{
+				"text": true,
+			}
+		}
+	}
+
+	return body
+}
+
+// splitCSV splits a comma-separated string into trimmed, non-empty parts.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/internal/integration/exa_load_test.go
+++ b/internal/integration/exa_load_test.go
@@ -1,0 +1,31 @@
+package integration
+
+import (
+	"testing"
+)
+
+func TestLoadExaDefinition(t *testing.T) {
+	def, err := LoadDefinition("../../registry/integrations/exa/integration.yaml")
+	if err != nil {
+		t.Fatalf("failed to load exa definition: %v", err)
+	}
+	if def.Name != "exa" {
+		t.Errorf("expected name 'exa', got: %s", def.Name)
+	}
+	if def.Auth.Method != "api_key" {
+		t.Errorf("expected auth method 'api_key', got: %s", def.Auth.Method)
+	}
+	if len(def.Actions) != 3 {
+		t.Errorf("expected 3 actions, got: %d", len(def.Actions))
+	}
+	for _, name := range []string{"search", "find_similar", "get_contents"} {
+		if _, ok := def.Actions[name]; !ok {
+			t.Errorf("expected action '%s'", name)
+		}
+	}
+	// Verify search action has correct auth header format
+	search := def.Actions["search"]
+	if search.AuthHeader != "x-api-key: {{token}}" {
+		t.Errorf("expected auth_header 'x-api-key: {{token}}', got: %s", search.AuthHeader)
+	}
+}

--- a/internal/integration/exa_test.go
+++ b/internal/integration/exa_test.go
@@ -1,0 +1,151 @@
+package integration
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildExaRequestBody_Search(t *testing.T) {
+	params := map[string]string{
+		"query":      "best Go frameworks",
+		"numResults": "10",
+		"type":       "auto",
+	}
+
+	body := BuildExaRequestBody("search", params)
+
+	// query should be a string
+	if body["query"] != "best Go frameworks" {
+		t.Errorf("expected query to be 'best Go frameworks', got: %v", body["query"])
+	}
+
+	// numResults should be coerced to int
+	if body["numResults"] != 10 {
+		t.Errorf("expected numResults to be int 10, got: %v (%T)", body["numResults"], body["numResults"])
+	}
+
+	// type should be a string
+	if body["type"] != "auto" {
+		t.Errorf("expected type to be 'auto', got: %v", body["type"])
+	}
+
+	// contents.highlights should be injected by default
+	contents, ok := body["contents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected contents to be a map, got: %T", body["contents"])
+	}
+	if contents["highlights"] != true {
+		t.Errorf("expected contents.highlights to be true, got: %v", contents["highlights"])
+	}
+}
+
+func TestBuildExaRequestBody_ArrayParams(t *testing.T) {
+	params := map[string]string{
+		"query":          "AI research",
+		"includeDomains": "arxiv.org, scholar.google.com",
+		"excludeDomains": "reddit.com",
+	}
+
+	body := BuildExaRequestBody("search", params)
+
+	include, ok := body["includeDomains"].([]string)
+	if !ok {
+		t.Fatalf("expected includeDomains to be []string, got: %T", body["includeDomains"])
+	}
+	expected := []string{"arxiv.org", "scholar.google.com"}
+	if !reflect.DeepEqual(include, expected) {
+		t.Errorf("expected includeDomains %v, got: %v", expected, include)
+	}
+
+	exclude, ok := body["excludeDomains"].([]string)
+	if !ok {
+		t.Fatalf("expected excludeDomains to be []string, got: %T", body["excludeDomains"])
+	}
+	if !reflect.DeepEqual(exclude, []string{"reddit.com"}) {
+		t.Errorf("expected excludeDomains [reddit.com], got: %v", exclude)
+	}
+}
+
+func TestBuildExaRequestBody_FindSimilar(t *testing.T) {
+	params := map[string]string{
+		"url":        "https://example.com/article",
+		"numResults": "3",
+	}
+
+	body := BuildExaRequestBody("find_similar", params)
+
+	if body["url"] != "https://example.com/article" {
+		t.Errorf("expected url, got: %v", body["url"])
+	}
+	if body["numResults"] != 3 {
+		t.Errorf("expected numResults 3, got: %v", body["numResults"])
+	}
+
+	// find_similar should also get default highlights
+	contents, ok := body["contents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected contents map, got: %T", body["contents"])
+	}
+	if contents["highlights"] != true {
+		t.Errorf("expected contents.highlights true")
+	}
+}
+
+func TestBuildExaRequestBody_GetContents(t *testing.T) {
+	params := map[string]string{
+		"ids": "https://example.com/a, https://example.com/b",
+	}
+
+	body := BuildExaRequestBody("get_contents", params)
+
+	ids, ok := body["ids"].([]string)
+	if !ok {
+		t.Fatalf("expected ids to be []string, got: %T", body["ids"])
+	}
+	if len(ids) != 2 {
+		t.Errorf("expected 2 ids, got: %d", len(ids))
+	}
+
+	// get_contents should inject contents.text by default
+	contents, ok := body["contents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected contents map, got: %T", body["contents"])
+	}
+	if contents["text"] != true {
+		t.Errorf("expected contents.text true")
+	}
+}
+
+func TestBuildExaRequestBody_InvalidNumResults(t *testing.T) {
+	params := map[string]string{
+		"query":      "test",
+		"numResults": "not-a-number",
+	}
+
+	body := BuildExaRequestBody("search", params)
+
+	// Should fall back to string when parsing fails
+	if body["numResults"] != "not-a-number" {
+		t.Errorf("expected numResults to be string fallback, got: %v", body["numResults"])
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a, b, c", []string{"a", "b", "c"}},
+		{"single", []string{"single"}},
+		{"a,,b", []string{"a", "b"}},
+		{" a , b ", []string{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		result := splitCSV(tt.input)
+		if !reflect.DeepEqual(result, tt.expected) {
+			t.Errorf("splitCSV(%q) = %v, want %v", tt.input, result, tt.expected)
+		}
+	}
+}

--- a/internal/integration/gateway.go
+++ b/internal/integration/gateway.go
@@ -163,8 +163,14 @@ func Invoke(req *InvokeRequest) (*InvokeResponse, error) {
 		req.Credential = refreshed
 	}
 
+	// Exa: build typed request body with nested objects and proper types
+	var customBody interface{}
+	if req.Integration == "exa" && actionDef.BodyFormat == "json" {
+		customBody = BuildExaRequestBody(req.Action, req.Params)
+	}
+
 	// Build HTTP request
-	httpReq, err := buildHTTPRequest(actionDef, req.Credential, req.Params)
+	httpReq, err := buildHTTPRequest(actionDef, req.Credential, req.Params, customBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build HTTP request: %w", err)
 	}
@@ -241,7 +247,7 @@ func refreshCredentialForIntegration(integrationName string, cred *Credential, w
 	return refreshed, nil
 }
 
-func buildHTTPRequest(action *Action, cred *Credential, params map[string]string) (*http.Request, error) {
+func buildHTTPRequest(action *Action, cred *Credential, params map[string]string, customBody interface{}) (*http.Request, error) {
 	endpoint := action.Endpoint
 
 	// Replace template variables in endpoint and track which params were used
@@ -257,13 +263,19 @@ func buildHTTPRequest(action *Action, cred *Credential, params map[string]string
 	var bodyReader io.Reader
 	switch action.BodyFormat {
 	case "json":
-		bodyMap := make(map[string]interface{})
-		for k, v := range params {
-			if !templateParams[k] {
-				bodyMap[k] = v
+		var data []byte
+		var err error
+		if customBody != nil {
+			data, err = json.Marshal(customBody)
+		} else {
+			bodyMap := make(map[string]interface{})
+			for k, v := range params {
+				if !templateParams[k] {
+					bodyMap[k] = v
+				}
 			}
+			data, err = json.Marshal(bodyMap)
 		}
-		data, err := json.Marshal(bodyMap)
 		if err != nil {
 			return nil, err
 		}
@@ -289,13 +301,15 @@ func buildHTTPRequest(action *Action, cred *Credential, params map[string]string
 		return nil, err
 	}
 
-	// Set auth header
-	authHeader := strings.ReplaceAll(action.AuthHeader, "{{token}}", cred.AccessToken)
-	if strings.HasPrefix(authHeader, "Bearer ") || strings.HasPrefix(authHeader, "token ") {
-		req.Header.Set("Authorization", authHeader)
-	} else {
-		req.Header.Set("Authorization", authHeader)
+	// Set auth header. If auth_header contains ": ", treat the left side as the
+	// header name (e.g., "x-api-key: {{token}}"). Otherwise default to Authorization.
+	authValue := strings.ReplaceAll(action.AuthHeader, "{{token}}", cred.AccessToken)
+	headerName := "Authorization"
+	if idx := strings.Index(action.AuthHeader, ": "); idx > 0 {
+		headerName = action.AuthHeader[:idx]
+		authValue = strings.ReplaceAll(action.AuthHeader[idx+2:], "{{token}}", cred.AccessToken)
 	}
+	req.Header.Set(headerName, authValue)
 
 	if action.BodyFormat == "json" {
 		req.Header.Set("Content-Type", "application/json")

--- a/registry/integrations/exa/integration.yaml
+++ b/registry/integrations/exa/integration.yaml
@@ -1,0 +1,98 @@
+name: exa
+description: Exa API — semantic web search with highlights, summaries, and content extraction
+auth:
+  method: api_key
+  setup_url: https://dashboard.exa.ai/api-keys
+  setup_instructions: |
+    1. Go to https://dashboard.exa.ai/api-keys and sign in (or create an account)
+    2. Click "Create API Key" and copy the key
+    3. Run `toc integrate add exa` and paste the key when prompted
+
+actions:
+  search:
+    description: Semantic search the web — returns highlighted snippets by default for token efficiency
+    scopes:
+      "*": any search query
+    params:
+      - name: query
+        required: true
+      - name: numResults
+        required: false
+        default: "5"
+      - name: type
+        required: false
+        default: auto
+      - name: category
+        required: false
+      - name: includeDomains
+        required: false
+      - name: excludeDomains
+        required: false
+      - name: startPublishedDate
+        required: false
+      - name: endPublishedDate
+        required: false
+      - name: includeText
+        required: false
+      - name: excludeText
+        required: false
+    method: POST
+    endpoint: https://api.exa.ai/search
+    auth_header: "x-api-key: {{token}}"
+    body_format: json
+    rate_limit:
+      max: 30
+      window: 60s
+    returns:
+      - results[].title
+      - results[].url
+      - results[].publishedDate
+      - results[].author
+      - results[].highlights
+
+  find_similar:
+    description: Find web pages similar to a given URL
+    scopes:
+      "*": any URL
+    params:
+      - name: url
+        required: true
+      - name: numResults
+        required: false
+        default: "5"
+      - name: includeDomains
+        required: false
+      - name: excludeDomains
+        required: false
+    method: POST
+    endpoint: https://api.exa.ai/findSimilar
+    auth_header: "x-api-key: {{token}}"
+    body_format: json
+    rate_limit:
+      max: 30
+      window: 60s
+    returns:
+      - results[].title
+      - results[].url
+      - results[].publishedDate
+      - results[].author
+      - results[].highlights
+
+  get_contents:
+    description: Get page content for known URLs — use when you have URLs and need their text
+    scopes:
+      "*": any URL
+    params:
+      - name: ids
+        required: true
+    method: POST
+    endpoint: https://api.exa.ai/contents
+    auth_header: "x-api-key: {{token}}"
+    body_format: json
+    rate_limit:
+      max: 30
+      window: 60s
+    returns:
+      - results[].title
+      - results[].url
+      - results[].text


### PR DESCRIPTION
## Summary
- Adds Exa integration with three actions: `search` (semantic web search with highlights by default), `find_similar` (find pages similar to a URL), and `get_contents` (fetch text for known URLs)
- Extends the gateway to support custom auth header names via `header: value` format in `auth_header` — Exa uses `x-api-key` instead of `Authorization`
- Adds Exa-specific body builder for proper typed JSON (integers, booleans, comma-separated arrays, nested `contents` object) — same integration-specific hook pattern as Slack's channel resolver

### Design decisions
- **Highlights by default**: Search and find_similar inject `contents.highlights: true` automatically — this is the most token-efficient format for agents
- **api_key auth**: Simple paste-the-key setup, no OAuth complexity. `toc integrate add exa` just works
- **Flat params → typed JSON**: Agent passes flat string params (`numResults=5`, `includeDomains=arxiv.org,scholar.google.com`), the Exa body builder handles type coercion and nesting
- **Custom auth header** is a generic gateway improvement (any future integration can use `header-name: value` format)

### Files changed
| File | What |
|------|------|
| `registry/integrations/exa/integration.yaml` | Integration definition (3 actions) |
| `internal/integration/exa.go` | Body builder: type coercion, arrays, nested contents |
| `internal/integration/gateway.go` | Custom auth headers + Exa body hook |
| `cmd/integrate_test_cmd.go` | `toc integrate test exa` support |
| `internal/integration/exa_test.go` | Unit tests for body builder |
| `internal/integration/exa_load_test.go` | YAML definition loading test |
| `e2e/integration_gateway_test.go` | E2E test: auth header, body typing, response filtering |

## Test plan
- [x] All existing tests pass (no regressions)
- [x] Exa body builder unit tests (search, find_similar, get_contents, array params, invalid input)
- [x] YAML definition validation test
- [x] E2E gateway test: verifies x-api-key header, typed JSON body, nested contents, response filtering
- [ ] Manual: `toc integrate add exa` → paste API key → `toc integrate test exa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)