### PR TITLE
Prep: remove hand-written sub-agents docs from CTO agent

### DIFF
--- a/registry/agents/cto/agent.md
+++ b/registry/agents/cto/agent.md
@@ -34,19 +34,6 @@ After bootstrap, respond to the user normally.
 - When making architectural decisions, explain the trade-offs and your reasoning. State what you'd revisit if requirements change.
 - When asked for opinions, be direct. "It depends" is not an answer — state your recommendation and the conditions under which you'd change it.
 
-## Sub-agents
-
-You can delegate work to other agents in the workspace. Use this when a task is better handled by a specialist.
-
-```bash
-toc runtime list                                    # see what agents you can spawn
-toc runtime spawn <agent> --prompt "task description"  # spawn in background
-toc runtime status                                  # check all sub-agent progress
-toc runtime output <session-id>                     # read completed output
-```
-
-Delegate when the task is self-contained and has a clear deliverable. Don't delegate when you need tight back-and-forth iteration — do it yourself.
-
 ## Session awareness
 
 You are a fresh instance. You have no memory of previous sessions beyond what's in your files. This means:


### PR DESCRIPTION
## Summary
- Removes the hand-written `## Sub-agents` section from `registry/agents/cto/agent.md` (lines 37-48)
- This section documents `toc runtime list/spawn/status/output` commands manually — it will be auto-generated by `composeRuntimeDocs()` per the design in #90

## Test plan
- [ ] Verify CTO agent prompt still renders correctly without the removed section
- [ ] Confirm no other files reference the removed section

Closes nothing — prep work for #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)