### PR TITLE
Add TLC setup skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- New `tlc-setup` skill: helps agents set up and configure the TLA+ TLC model checker with CLI-first, repo-friendly workflows for specs, config files, and CI automation.
+
 ## [0.3.3] - 2026-03-25
 
 ### Changed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ toc agent spawn pr-reviewer
 │   └── usage/                 # Token usage parsing and formatting
 ├── registry/                  # Built-in skills, agents, and integration definitions
 │   ├── agents/                # cto, mini-claw
-│   ├── skills/                # open-source-cto, agentic-memory
+│   ├── skills/                # open-source-cto, agentic-memory, tlc-setup
 │   └── integrations/          # github, slack
 ├── web/                       # OAuth callback worker (Cloudflare)
 ├── e2e/                       # End-to-end smoke tests

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -115,6 +115,7 @@ The toc registry includes skills and agent templates:
 |---|---|---|
 | `open-source-cto` | skill | Technical decision-making and code quality standards from an open-source CTO perspective |
 | `agentic-memory` | skill | Persistent memory system with daily logs and long-term storage for cross-session continuity |
+| `tlc-setup` | skill | Set up and configure the TLA+ TLC model checker in a repo, including CLI workflows, config files, and CI-friendly automation |
 | `cto` | agent | Technical leadership agent — code quality, architecture, and open-source standards |
 | `mini-claw` | agent | Persistent agent with identity, memory, and session awareness — inspired by OpenClaw |
 

--- a/registry/skills/index.yaml
+++ b/registry/skills/index.yaml
@@ -5,3 +5,6 @@ skills:
   - name: agentic-memory
     description: Persistent memory system with daily logs and long-term storage for cross-session continuity
     tags: [memory, persistence, agentic, continuity]
+  - name: tlc-setup
+    description: Set up and configure the TLA+ TLC model checker in a repo, including CLI workflows, config files, and CI-friendly automation
+    tags: [tlc, tla-plus, formal-methods, verification, setup]

--- a/registry/skills/tlc-setup/SKILL.md
+++ b/registry/skills/tlc-setup/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: tlc-setup
+description: Set up and configure the TLA+ TLC model checker in a repo, including CLI workflows, config files, and CI-friendly automation
+license: MIT
+compatibility: claude-code
+---
+
+# tlc-setup
+
+Use this skill when the user wants help setting up TLC, wiring TLA+ into a repository, creating runnable `.tla` and `.cfg` files, or turning a natural-language system description into a reproducible model-checking workflow.
+
+Prefer a repo-local, scriptable setup over editor-only instructions. The goal is to leave behind files and commands that humans, CI, and coding agents can all run the same way.
+
+## Workflow
+
+1. Determine the scope of the request.
+   Typical scopes: first-time install, initial spec scaffolding, config cleanup, CI wiring, or troubleshooting an existing TLC run.
+2. Inspect the repository before changing anything.
+   Look for existing `*.tla`, `*.cfg`, Java setup, wrapper scripts, `Makefile` targets, and CI workflows. Reuse the existing layout if one already exists.
+3. Default to CLI-first TLC setup.
+   TLC is easiest to automate through `tla2tools.jar`. Prefer a checked-in script or `make` target so the same entrypoint works locally and in CI.
+4. Create the smallest runnable model that matches the user's request.
+   Start with a finite model, explicit constants, a named behavior spec, and at least one invariant. Avoid premature liveness checks or large state spaces.
+5. Keep configuration explicit.
+   Prefer `SPECIFICATION Spec` in the `.cfg` file when the module already defines `Spec`. Use `INIT` and `NEXT` only when the spec has not been wrapped into a single behavior operator yet.
+6. Keep operational output out of the source tree where practical.
+   Direct TLC metadata and generated state-space files into a generated directory such as `.tlc/`.
+7. Verify the baseline before tuning.
+   Get one successful TLC run first. Only then add worker, memory, coverage, dump, or trace-export options if the user actually needs them.
+8. Explain the modeling assumptions.
+   Call out bounded constants, omitted real-world detail, fairness assumptions, and anything that keeps the model finite.
+
+## Defaults
+
+- Prefer a directory like `specs/` unless the repository already has a clear convention.
+- Prefer one small wrapper script over scattered ad hoc shell commands.
+- Keep the TLC invocation deterministic and visible in versioned files.
+- Do not commit downloaded jars unless the repository already vendors binaries.
+- If the user mentions PlusCal, preserve hand-edited `.cfg` files by using `pcal.trans -nocfg` when appropriate.
+
+## Natural-language mapping
+
+- "Set up TLC for this service" means: install or reference `tla2tools.jar`, scaffold a spec directory, create a runnable `.cfg`, and add a script or `make` target.
+- "Model-check this workflow" means: derive a minimal state model from the workflow, encode bounds and invariants explicitly, and run TLC on a finite instance.
+- "Add TLC to CI" means: make the CLI path the source of truth, install Java in CI, fetch or reference the jar, and run the same wrapper used locally.
+- "Fix this TLC config" means: inspect operator names, constants, module filenames, spec/config alignment, and state-space bounds before changing flags.
+
+## Guardrails
+
+- Keep module filenames and `---- MODULE Name ----` aligned.
+- Keep `.cfg` references pointed at named operators that actually exist in the module.
+- Prefer type invariants and small bounded constants first; they catch real mistakes quickly.
+- If the model explodes, reduce constants or introduce stronger state constraints before reaching for advanced flags.
+- If the request is really about TLAPS or Apalache, say so explicitly; those are different tools with different workflows.
+
+For command templates, config skeletons, and a reusable wrapper pattern, read [references/cli-setup.md](references/cli-setup.md).

--- a/registry/skills/tlc-setup/references/cli-setup.md
+++ b/registry/skills/tlc-setup/references/cli-setup.md
@@ -1,0 +1,119 @@
+# TLC CLI Setup
+
+Use this reference when you need concrete commands, file layout, or a starter wrapper while applying the `tlc-setup` skill.
+
+## Install
+
+- TLC is distributed in `tla2tools.jar`.
+- The TLA+ tools require Java 11 or newer.
+- The most automation-friendly install path is:
+
+```bash
+mkdir -p tools/tla
+curl -L https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar \
+  -o tools/tla/tla2tools.jar
+```
+
+- If the repository already depends on a developer-managed TLA+ installation, prefer an environment variable like `TLA2TOOLS_JAR` instead of adding a second copy.
+- VS Code and the Toolbox can still be used, but keep the CLI invocation as the canonical project entrypoint.
+
+## Suggested layout
+
+```text
+specs/
+  Counter.tla
+  Counter.cfg
+scripts/
+  run-tlc
+tools/
+  tla/
+    tla2tools.jar
+.tlc/
+```
+
+Use the existing repository layout if it is already coherent.
+
+## Minimal module
+
+```tla
+---- MODULE Counter ----
+EXTENDS Naturals
+
+CONSTANT Limit
+VARIABLE value
+
+Init == value = 0
+
+Next == value' \in 0..Limit
+
+TypeInvariant == value \in 0..Limit
+
+Spec == Init /\ [][Next]_<<value>>
+
+====
+```
+
+This is intentionally small. Replace it with domain-specific variables and actions once the workflow is running.
+
+## Minimal config
+
+```text
+SPECIFICATION Spec
+INVARIANT TypeInvariant
+CONSTANT
+  Limit = 3
+```
+
+Notes:
+
+- If you omit `-config`, TLC looks for a sibling `.cfg` file with the same basename as the `.tla` file.
+- If the module does not define `Spec`, use:
+
+```text
+INIT Init
+NEXT Next
+INVARIANT TypeInvariant
+```
+
+## Wrapper script pattern
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+JAR="${TLA2TOOLS_JAR:-tools/tla/tla2tools.jar}"
+SPEC="${1:-specs/Counter.tla}"
+CFG="${2:-${SPEC%.tla}.cfg}"
+NAME="$(basename "${SPEC%.tla}")"
+META_DIR="${3:-.tlc/${NAME}}"
+
+mkdir -p "$META_DIR"
+
+java -jar "$JAR" \
+  -config "$CFG" \
+  -metadir "$META_DIR" \
+  -workers auto \
+  "$SPEC"
+```
+
+This keeps the default path simple while still allowing local overrides.
+
+## PlusCal note
+
+If the spec is written in PlusCal and you want to keep a hand-edited config file, run:
+
+```bash
+java -cp tools/tla/tla2tools.jar pcal.trans -nocfg specs/Counter.tla
+```
+
+Without `-nocfg`, the translator writes or overwrites `Counter.cfg`.
+
+## CI pattern
+
+In CI:
+
+1. Install Java 11+.
+2. Fetch `tla2tools.jar` if the repo does not already provide it.
+3. Run the same wrapper script used locally.
+
+Keep CI bounded and deterministic. Prefer one or two small models over a large exploratory state space.


### PR DESCRIPTION
## Summary
- add a new built-in  skill for TLA+ TLC setup and configuration
- include a focused CLI reference with install, wrapper script, config, and CI patterns
- register the skill in the built-in registry and document it in the skills docs and changelog

## Testing
- go test ./...