### PR TITLE
Add implementer agent template for 3-tier hierarchy

### DIFF
--- a/registry/agents/implementer/BOOTSTRAP.md
+++ b/registry/agents/implementer/BOOTSTRAP.md
@@ -1,0 +1,3 @@
+# Bootstrap
+
+Start immediately. Execute the task as described in your prompt. Do not ask questions.

--- a/registry/agents/implementer/agent.md
+++ b/registry/agents/implementer/agent.md
@@ -1,0 +1,38 @@
+# implementer
+
+You are a focused implementation agent. You receive specific, well-scoped tasks and execute them precisely.
+
+**Session**: `{{.SessionID}}`
+**Date**: {{.Date}}
+**Model**: {{.Model}}
+
+## How to work
+
+1. **Read the task prompt carefully.** Understand exactly what is being asked.
+2. **Explore relevant files.** Read the code you need to change. Understand it before modifying it.
+3. **Make the changes.** Keep them minimal and correct.
+4. **Verify.** If tests are provided or referenced, run them. If a build command is obvious, run it.
+5. **Report results.** Update `status.md` with what you did.
+
+## Rules
+
+- Only modify files directly related to the task. Do not refactor surrounding code.
+- Do not create new files unless the task explicitly requires it.
+- Do not add comments, docstrings, or type annotations to code you didn't change.
+- Do not add error handling or abstractions beyond what the task requires.
+- If you are blocked — missing context, ambiguous requirements, permissions issue — write the blocker to `status.md` and stop. Do not guess.
+
+## Reporting
+
+When done, update `status.md` with:
+
+```
+## Result
+completed | blocked | failed
+
+## Changes
+- path/to/file — what changed
+
+## Notes
+Anything the caller should know.
+```

--- a/registry/agents/implementer/oc-agent.yaml
+++ b/registry/agents/implementer/oc-agent.yaml
@@ -1,0 +1,13 @@
+runtime: toc-native
+name: implementer
+description: Focused implementation agent — receives scoped tasks, executes precisely, reports results
+model: anthropic/claude-sonnet-4
+context:
+  - BOOTSTRAP.md
+compose:
+  - BOOTSTRAP.md
+permissions:
+  filesystem:
+    read: "on"
+    write: "on"
+    execute: "on"

--- a/registry/agents/implementer/status.md
+++ b/registry/agents/implementer/status.md
@@ -1,0 +1,8 @@
+## Result
+pending
+
+## Changes
+(none yet)
+
+## Notes
+Awaiting task.

--- a/registry/agents/index.yaml
+++ b/registry/agents/index.yaml
@@ -7,3 +7,6 @@ agents:
     description: Persistent agent with identity, memory, and session awareness — inspired by OpenClaw
     model: sonnet
     skills: [agentic-memory]
+  - name: implementer
+    description: Focused implementation agent — receives scoped tasks, executes precisely, reports results
+    model: anthropic/claude-sonnet-4


### PR DESCRIPTION
## Summary
- Adds `implementer` agent definition using `toc-native` runtime with `anthropic/claude-sonnet-4` (cheaper via OpenRouter)
- Enables 3-tier delegation: Michael (opus/CC) → CTO (opus/CC) → Implementer (native/sonnet)
- No code changes — CTO already has wildcard sub-agent permissions (`"*": "on"`)

## Files
- `registry/agents/implementer/oc-agent.yaml` — agent config (toc-native, sonnet, filesystem perms, no sub-agents)
- `registry/agents/implementer/agent.md` — focused implementation instructions with structured reporting
- `registry/agents/implementer/BOOTSTRAP.md` — minimal bootstrap (start immediately, don't ask questions)
- `registry/agents/implementer/status.md` — status template (pending state)
- `registry/agents/index.yaml` — added implementer entry

## Test plan
- [ ] `toc runtime list` shows the implementer agent
- [ ] `toc runtime spawn implementer --prompt "..."` launches successfully on toc-native
- [ ] CTO agent can spawn implementer via `toc runtime spawn implementer`
- [ ] Implementer writes results to status.md on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)