### PR TITLE
Update implementer agent to openai/gpt-5.3-codex

### DIFF
--- a/registry/agents/implementer/oc-agent.yaml
+++ b/registry/agents/implementer/oc-agent.yaml
@@ -1,7 +1,8 @@
 runtime: toc-native
 name: implementer
 description: Focused implementation agent — receives scoped tasks, executes precisely, reports results
-model: anthropic/claude-sonnet-4
+model: openai/gpt-5.3-codex
+allow_custom_native_model: true
 context:
   - BOOTSTRAP.md
 compose:


### PR DESCRIPTION
## Summary
- Switch implementer agent model from `anthropic/claude-sonnet-4` to `openai/gpt-5.3-codex`
- Enable `allow_custom_native_model: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)