### PR TITLE
fix: resolve credentials from workspace root, not CWD

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -86,7 +86,9 @@ var configGetKeyCmd = &cobra.Command{
 			return fmt.Errorf("unknown provider '%s' — supported providers: openrouter", provider)
 		}
 
-		secrets, err := config.LoadSecrets()
+		// Load secrets from workspace root — handles both direct workspace
+		// and session context (where CWD is a temp dir but TOC_WORKSPACE is set).
+		secrets, err := config.LoadSecretsFrom(config.WorkspaceRoot())
 		if err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,8 +61,24 @@ func AuditLogPath() string {
 	return filepath.Join(tocDir, "audit.log")
 }
 
+// WorkspaceRoot returns the effective workspace root directory.
+// If TOC_WORKSPACE is set (indicating we're running inside a session),
+// it returns that path. Otherwise it returns "." (current directory).
+func WorkspaceRoot() string {
+	if ws := os.Getenv("TOC_WORKSPACE"); ws != "" {
+		return ws
+	}
+	return "."
+}
+
 func Exists() bool {
 	_, err := os.Stat(ConfigPath())
+	return err == nil
+}
+
+// ExistsIn checks whether a workspace is initialized at the given root.
+func ExistsIn(root string) bool {
+	_, err := os.Stat(filepath.Join(root, tocDir, configFile))
 	return err == nil
 }
 
@@ -87,10 +103,28 @@ func Save(cfg *WorkspaceConfig) error {
 }
 
 func EnsureInitialized() (*WorkspaceConfig, error) {
-	if !Exists() {
-		return nil, fmt.Errorf("this directory is not a toc workspace — run 'toc init' first")
+	if Exists() {
+		return Load()
 	}
-	return Load()
+	// If CWD is not a workspace but TOC_WORKSPACE is set (session context),
+	// check and load from there instead.
+	if ws := os.Getenv("TOC_WORKSPACE"); ws != "" && ExistsIn(ws) {
+		return LoadFrom(ws)
+	}
+	return nil, fmt.Errorf("this directory is not a toc workspace — run 'toc init' first")
+}
+
+// LoadFrom reads the workspace config from a specific root directory.
+func LoadFrom(root string) (*WorkspaceConfig, error) {
+	data, err := os.ReadFile(filepath.Join(root, tocDir, configFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+	var cfg WorkspaceConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	return &cfg, nil
 }
 
 func Init(name string) error {
@@ -135,8 +169,36 @@ func SaveSecrets(s *Secrets) error {
 }
 
 // OpenRouterKey returns the stored OpenRouter API key, or empty string if not set.
+// It reads from .toc/secrets.yaml relative to the current working directory.
 func OpenRouterKey() string {
 	s, err := LoadSecrets()
+	if err != nil {
+		return ""
+	}
+	return s.OpenRouterKey
+}
+
+// LoadSecretsFrom reads the secrets file from a specific workspace root directory.
+// Returns an empty Secrets if the file does not exist.
+func LoadSecretsFrom(workspaceRoot string) (*Secrets, error) {
+	data, err := os.ReadFile(filepath.Join(workspaceRoot, tocDir, secretsFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Secrets{}, nil
+		}
+		return nil, fmt.Errorf("failed to read secrets: %w", err)
+	}
+	var s Secrets
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("failed to parse secrets: %w", err)
+	}
+	return &s, nil
+}
+
+// OpenRouterKeyFrom returns the stored OpenRouter API key from a specific workspace root,
+// or empty string if not set. This is used by the runtime when CWD differs from workspace.
+func OpenRouterKeyFrom(workspaceRoot string) string {
+	s, err := LoadSecretsFrom(workspaceRoot)
 	if err != nil {
 		return ""
 	}

--- a/internal/runtime/native.go
+++ b/internal/runtime/native.go
@@ -111,9 +111,11 @@ func (nativeProvider) LaunchInteractive(opts LaunchOptions) error {
 		"TOC_SESSION_ID="+opts.SessionID,
 	)
 
-	// Inject stored OpenRouter key if not already in the environment
+	// Inject stored OpenRouter key if not already in the environment.
+	// Read from the workspace root, not CWD — the process may be running
+	// from a session temp dir that has no .toc/secrets.yaml.
 	if os.Getenv("OPENROUTER_API_KEY") == "" {
-		if key := config.OpenRouterKey(); key != "" {
+		if key := config.OpenRouterKeyFrom(opts.Workspace); key != "" {
 			cmd.Env = append(cmd.Env, "OPENROUTER_API_KEY="+key)
 		}
 	}
@@ -179,10 +181,12 @@ func BuildNativeDetachedScript(executable string, opts DetachedOptions, promptPa
 		command += " --resume"
 	}
 
-	// Inject stored OpenRouter key into detached script if not in current env
+	// Inject stored OpenRouter key into detached script if not in current env.
+	// Read from the workspace root, not CWD — the spawning process may be
+	// running from a session temp dir that has no .toc/secrets.yaml.
 	openRouterExport := ""
 	if os.Getenv("OPENROUTER_API_KEY") == "" {
-		if key := config.OpenRouterKey(); key != "" {
+		if key := config.OpenRouterKeyFrom(opts.Workspace); key != "" {
 			openRouterExport = fmt.Sprintf("export OPENROUTER_API_KEY=%q\n", key)
 		}
 	}

--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -63,7 +63,7 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 	}
 	profile := runtimeinfo.ResolveNativeProfile(state.Model)
 
-	client, err := newOpenRouterClientFromEnv()
+	client, err := newOpenRouterClientFromEnv(opts.Workspace)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/openrouter.go
+++ b/internal/runtime/openrouter.go
@@ -207,11 +207,12 @@ type streamToolCallDelta struct {
 	} `json:"function"`
 }
 
-func newOpenRouterClientFromEnv() (*openRouterClient, error) {
+func newOpenRouterClientFromEnv(workspaceRoot string) (*openRouterClient, error) {
 	apiKey := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY"))
 	if apiKey == "" {
-		// Fall back to stored key in workspace secrets
-		apiKey = config.OpenRouterKey()
+		// Fall back to stored key in workspace secrets.
+		// Use the workspace root explicitly — CWD is a session temp dir.
+		apiKey = config.OpenRouterKeyFrom(workspaceRoot)
 	}
 	if apiKey == "" {
 		return nil, fmt.Errorf("OpenRouter API key not found.\n\n" +


### PR DESCRIPTION
## Summary

Fixes the bug where sub-agent sessions (especially toc-native implementer agents) fail with "OpenRouter API key not found" when spawned from other agents running in session temp dirs.

**Root cause:** All credential resolution (`config.OpenRouterKey()`, `config.LoadSecrets()`, `config.EnsureInitialized()`) reads `.toc/secrets.yaml` relative to CWD. When an agent runs in a session sandbox (`/tmp/toc-sessions/cto-XXXX/`), CWD has no `.toc/` directory. The workspace path IS available via `TOC_WORKSPACE` env var and `--workspace` flag, but was never used for credential lookups.

**Three broken code paths fixed:**
- `native.go` — key injection for both inline and detached native launches now reads from `opts.Workspace`
- `openrouter.go` — `newOpenRouterClientFromEnv()` now accepts workspace root parameter  
- `cmd/config.go` — `toc config get-key` now uses `config.WorkspaceRoot()` which checks `TOC_WORKSPACE`

**New workspace-aware functions in config package:**
- `WorkspaceRoot()` — returns `TOC_WORKSPACE` if set, else `"."`
- `ExistsIn(root)` — checks workspace initialization at a specific path
- `LoadFrom(root)` — loads workspace config from specific root
- `LoadSecretsFrom(root)` — loads secrets from specific root  
- `OpenRouterKeyFrom(root)` — reads OpenRouter key from specific root
- `EnsureInitialized()` — now falls back to `TOC_WORKSPACE` when CWD is not a workspace

## Test plan

- [x] `go test ./...` — all tests pass (including e2e and spawn tests)
- [ ] Manual: run `toc config get-key openrouter` from a session temp dir with `TOC_WORKSPACE` set — should succeed
- [ ] Manual: spawn a toc-native implementer from a CTO sub-agent — should get OpenRouter key
- [ ] Verify `toc config get-key` still works normally from workspace dir (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)