### PR TITLE
feat: show active integrations in session startup banner

### DIFF
--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -120,6 +122,7 @@ func SpawnSession(cfg *agent.AgentConfig, opts ...SpawnOptions) (*SpawnResult, e
 	if sessionCfg.OnEnd != "" {
 		ui.Info("On end: %s", ui.Dim("session end hook enabled"))
 	}
+	ui.Info("Integrations: %s", ui.Dim(integrationsSummary(sessionCfg)))
 	if permissionsConfigured(sessionCfg) {
 		ui.Info("Permissions: %s", ui.Dim("enforced via hooks"))
 	}
@@ -190,6 +193,7 @@ func ResumeSession(s *session.Session) (*SpawnResult, error) {
 		resolved := len(sessionCfg.Skills) - len(failedSkills)
 		ui.Info("Skills: %s", ui.Dim(fmt.Sprintf("%d/%d resolved", resolved, len(sessionCfg.Skills))))
 	}
+	ui.Info("Integrations: %s", ui.Dim(integrationsSummary(sessionCfg)))
 	fmt.Println()
 
 	_ = session.UpdateStatus(s.ID, session.StatusActive)
@@ -524,6 +528,24 @@ func writePermissionManifest(metadataDir, sessionID string, cfg *runtime.Session
 // explicit workspace path. Used for sub-agent spawning.
 func writePermissionManifestInWorkspace(workspace, sessionID string, cfg *runtime.SessionConfig) error {
 	return writePermissionManifest(filepath.Join(workspace, ".toc", "sessions", sessionID), sessionID, cfg)
+}
+
+func integrationsSummary(cfg *runtime.SessionConfig) string {
+	if cfg == nil || len(cfg.Permissions.Integrations) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(cfg.Permissions.Integrations))
+	for name := range cfg.Permissions.Integrations {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, len(names))
+	for i, name := range names {
+		n := len(cfg.Permissions.Integrations[name])
+		parts[i] = fmt.Sprintf("%s (%d action(s))", name, n)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func permissionsConfigured(cfg *runtime.SessionConfig) bool {

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -20,6 +20,61 @@ import (
 	"github.com/tiny-oc/toc/internal/session"
 )
 
+func TestIntegrationsSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *runtime.SessionConfig
+		want string
+	}{
+		{
+			name: "nil config",
+			cfg:  nil,
+			want: "none",
+		},
+		{
+			name: "no integrations",
+			cfg:  &runtime.SessionConfig{},
+			want: "none",
+		},
+		{
+			name: "single integration",
+			cfg: &runtime.SessionConfig{
+				Permissions: agent.Permissions{
+					Integrations: map[string]agent.IntegrationPermissions{
+						"slack": {
+							{Mode: agent.PermOn, Capability: "post:#eng"},
+							{Mode: agent.PermAsk, Capability: "post:channels/*"},
+							{Mode: agent.PermOn, Capability: "read:channels/*"},
+						},
+					},
+				},
+			},
+			want: "slack (3 action(s))",
+		},
+		{
+			name: "multiple integrations sorted",
+			cfg: &runtime.SessionConfig{
+				Permissions: agent.Permissions{
+					Integrations: map[string]agent.IntegrationPermissions{
+						"exa":   {{Mode: agent.PermOn, Capability: "search"}, {Mode: agent.PermOn, Capability: "find_similar"}, {Mode: agent.PermOn, Capability: "contents"}},
+						"slack":  {{Mode: agent.PermOn, Capability: "post:#eng"}},
+					},
+				},
+			},
+			want: "exa (3 action(s)), slack (1 action(s))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := integrationsSummary(tt.cfg)
+			if got != tt.want {
+				t.Errorf("integrationsSummary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildDetachedScript_PIDTracking(t *testing.T) {
 	dir := t.TempDir()
 	promptPath := filepath.Join(dir, "toc-prompt.txt")


### PR DESCRIPTION
## Summary
- Adds an `Integrations:` line to the session startup banner showing each active integration and its action count (e.g. `slack (3 action(s)), exa (3 action(s))`) or `none` if no integrations are configured.
- Reads from the existing `SessionConfig.Permissions.Integrations` — no new config parsing needed.
- Shows the line in both spawn and resume banners.

## Test plan
- [x] Unit tests for `integrationsSummary` covering nil config, no integrations, single, and multiple (sorted) integrations
- [x] Full test suite passes (`go test -short ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)