### PR TITLE
Improve Slack setup wizard with step-by-step OAuth guidance

### DIFF
--- a/cmd/integrate_add.go
+++ b/cmd/integrate_add.go
@@ -246,49 +246,64 @@ func runOAuth2Flow(name string, def *integration.Definition, manual bool, flagCl
 }
 
 // showSetupWizard displays the integration's setup instructions as a numbered
-// wizard with pauses between steps so the user can complete each one.
+// wizard with pauses between sections so the user can complete each one.
 func showSetupWizard(def *integration.Definition) {
 	ui.Header("Setup wizard")
 
-	lines := strings.Split(strings.TrimSpace(def.Auth.SetupInstructions), "\n")
-
-	// Show required scopes up front
-	scopes := def.Auth.UserScopes
-	if len(scopes) == 0 {
-		scopes = def.Auth.RequiredScopes
-	}
-	if len(scopes) > 0 {
-		ui.Info("Required scopes: %s", ui.Bold(strings.Join(scopes, ", ")))
-		fmt.Println()
+	// Parse instructions into sections delimited by === HEADING === lines.
+	// Each section is displayed together, with a pause between sections.
+	type section struct {
+		heading string
+		lines   []string
 	}
 
-	// Filter out blank lines so the "last step" check is accurate.
-	var steps []string
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			steps = append(steps, line)
+	raw := strings.Split(strings.TrimSpace(def.Auth.SetupInstructions), "\n")
+	var sections []section
+	cur := section{}
+
+	for _, line := range raw {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "===") && strings.HasSuffix(trimmed, "===") {
+			// Start a new section; flush the previous one if it has content.
+			if len(cur.lines) > 0 || cur.heading != "" {
+				sections = append(sections, cur)
+			}
+			heading := strings.Trim(trimmed, "= ")
+			cur = section{heading: heading}
+		} else if trimmed != "" {
+			cur.lines = append(cur.lines, trimmed)
 		}
 	}
+	if len(cur.lines) > 0 || cur.heading != "" {
+		sections = append(sections, cur)
+	}
 
-	for i, line := range steps {
-		// Highlight the redirect URL step
-		if strings.Contains(line, "Redirect URL") || strings.Contains(line, "redirect_uri") || strings.Contains(line, integration.SlackOAuthCallbackURL) {
-			fmt.Println("  " + ui.Yellow(line))
+	for i, sec := range sections {
+		if sec.heading != "" {
 			fmt.Println()
-			ui.Warn("OAuth will fail if the redirect URL is not added exactly as shown above.")
-			fmt.Println()
-		} else {
-			fmt.Println("  " + line)
-			fmt.Println()
+			ui.Header(sec.heading)
 		}
 
-		// Pause between steps (except the last one, which is usually "run toc integrate add")
-		if i < len(steps)-1 {
+		for _, line := range sec.lines {
+			// Highlight the redirect URL line
+			if strings.Contains(line, integration.SlackOAuthCallbackURL) {
+				fmt.Println("  " + ui.Yellow(line))
+				ui.Warn("OAuth will fail if the redirect URL is not added exactly as shown.")
+			} else if strings.HasPrefix(line, "-") || strings.HasPrefix(line, "  -") {
+				// Scope detail lines — use dimmer formatting for annotations
+				fmt.Println("      " + line)
+			} else {
+				fmt.Println("  " + line)
+			}
+		}
+
+		// Pause between sections (except the last one, which tells them to come back)
+		if i < len(sections)-1 {
+			fmt.Println()
 			ui.WaitForEnter("Press Enter when ready for the next step...")
-			fmt.Println()
 		}
 	}
+	fmt.Println()
 }
 
 // runHostedOAuth2Flow opens the browser and starts a localhost callback server.

--- a/registry/integrations/slack/integration.yaml
+++ b/registry/integrations/slack/integration.yaml
@@ -16,12 +16,42 @@ auth:
     - reactions:write
     - search:read
   setup_instructions: |
+    === WHY USER TOKENS ===
+    This integration uses Slack USER tokens (xoxp), not bot tokens (xoxb).
+    Messages are posted as you (your name, your avatar, no APP badge).
+    You get access to search — bots cannot use search.messages.
+
+    === CREATE YOUR SLACK APP ===
     1. Go to https://api.slack.com/apps and sign in
-    2. Click "Create New App" → "From scratch" (or select an existing app)
-    3. Go to "OAuth & Permissions" in the sidebar
-    4. Under "Redirect URLs", add: https://toc-auth-callback.dev-f64.workers.dev/slack/callback
-    5. Note your Client ID and Client Secret from "Basic Information"
-    6. Run `toc integrate add slack` and paste them when prompted
+    2. Click "Create New App" → choose "From scratch"
+    3. Enter any app name (e.g. "toc") and select your workspace
+    4. Click "Create App"
+
+    === ADD THE REDIRECT URL ===
+    5. In the left sidebar, click "OAuth & Permissions"
+    6. Scroll to "Redirect URLs" and click "Add New Redirect URL"
+    7. Paste exactly: https://toc-auth-callback.dev-f64.workers.dev/slack/callback
+    8. Click "Add" then "Save URLs"
+
+    === ADD USER TOKEN SCOPES ===
+    9. On the same page, scroll down to "User Token Scopes" (NOT "Bot Token Scopes")
+    10. Click "Add an OAuth Scope" and add each of these:
+        - channels:read       → list public channels
+        - groups:read         → list private channels
+        - im:read             → list direct messages
+        - mpim:read           → list group DMs
+        - channels:history    → read public channel messages
+        - groups:history      → read private channel messages
+        - im:history          → read DM messages
+        - mpim:history        → read group DM messages
+        - chat:write          → send messages as you
+        - reactions:write     → add emoji reactions
+        - search:read         → search messages across your workspace
+
+    === GET YOUR CREDENTIALS ===
+    11. In the left sidebar, click "Basic Information"
+    12. Scroll to "App Credentials" — copy the Client ID and Client Secret
+    13. Come back here and paste them when prompted
 
 capabilities:
   post:


### PR DESCRIPTION
## Summary
- Rewrote the Slack integration setup instructions from 6 vague lines to 13 explicit steps organized into 4 sections (why user tokens, create app, add redirect URL, add scopes, get credentials)
- Each scope is listed with what it unlocks so users know why they're adding it
- Explains upfront why user tokens (xoxp) instead of bot tokens — posts as you, enables search, no APP badge
- Updated the wizard renderer to parse `=== SECTION ===` delimiters and pause between sections instead of between every individual line

## Scope audit
Verified all 11 user token scopes against current Slack API docs (docs.slack.dev):
- `channels:read`, `groups:read`, `im:read`, `mpim:read` — correct for `conversations.list` (no `conversations:read` scope exists)
- `channels:history`, `groups:history`, `im:history`, `mpim:history` — correct for `conversations.history`
- `chat:write` — correct for `chat.postMessage` with user token (replaces legacy `chat:write:user`)
- `reactions:write` — correct for `reactions.add`
- `search:read` — correct for `search.messages` (user token only, bots cannot search)

No scopes are deprecated, missing, or unnecessary.

## Test plan
- [ ] `go test ./...` passes (verified locally)
- [ ] Run `toc integrate add slack` and confirm the wizard displays sections with clear pauses
- [ ] Follow the wizard steps on a fresh Slack app — verify each step maps to actual Slack UI
- [ ] Complete OAuth flow end-to-end and verify `auth.test` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)