### PR TITLE
feat: configurable max tool iterations for toc-native agents

### DIFF
--- a/cmd/agent_spawn.go
+++ b/cmd/agent_spawn.go
@@ -11,13 +11,15 @@ import (
 )
 
 var (
-	resumeSessionID string
-	spawnPrompt     string
+	resumeSessionID    string
+	spawnPrompt        string
+	spawnMaxIterations int
 )
 
 func init() {
 	agentSpawnCmd.Flags().StringVar(&resumeSessionID, "resume", "", "Resume an existing session by ID")
 	agentSpawnCmd.Flags().StringVarP(&spawnPrompt, "prompt", "p", "", "Run a single prompt non-interactively and exit")
+	agentSpawnCmd.Flags().IntVar(&spawnMaxIterations, "max-iterations", 0, "Override max tool iterations for this session (0 = use agent/env/default)")
 	agentSpawnCmd.RegisterFlagCompletionFunc("resume", completeSessionIDs)
 	agentCmd.AddCommand(agentSpawnCmd)
 }
@@ -61,7 +63,7 @@ var agentSpawnCmd = &cobra.Command{
 			return err
 		}
 
-		result, err := spawn.SpawnSession(cfg, spawn.SpawnOptions{Prompt: spawnPrompt})
+		result, err := spawn.SpawnSession(cfg, spawn.SpawnOptions{Prompt: spawnPrompt, MaxIterations: spawnMaxIterations})
 		if result != nil {
 			details := map[string]interface{}{
 				"agent":      agentName,

--- a/cmd/runtime_spawn.go
+++ b/cmd/runtime_spawn.go
@@ -14,10 +14,12 @@ import (
 
 var runtimeSpawnPrompt string
 var runtimeSpawnResume string
+var runtimeSpawnMaxIterations int
 
 func init() {
 	runtimeSpawnCmd.Flags().StringVarP(&runtimeSpawnPrompt, "prompt", "p", "", "Task prompt for the sub-agent")
 	runtimeSpawnCmd.Flags().StringVar(&runtimeSpawnResume, "resume", "", "Resume a failed or cancelled sub-agent session by ID")
+	runtimeSpawnCmd.Flags().IntVar(&runtimeSpawnMaxIterations, "max-iterations", 0, "Override max tool iterations for the sub-agent (0 = use agent/env/default)")
 	runtimeCmd.AddCommand(runtimeSpawnCmd)
 }
 
@@ -75,6 +77,7 @@ var runtimeSpawnCmd = &cobra.Command{
 			ParentSessionID: ctx.SessionID,
 			Prompt:          runtimeSpawnPrompt,
 			WorkspaceDir:    ctx.Workspace,
+			MaxIterations:   runtimeSpawnMaxIterations,
 		})
 		if err != nil {
 			return err

--- a/internal/runtime/session_config.go
+++ b/internal/runtime/session_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/tiny-oc/toc/internal/agent"
 	"github.com/tiny-oc/toc/internal/integration"
@@ -44,9 +45,19 @@ type SessionConfig struct {
 	LLM                    SessionLLMConfig      `json:"llm,omitempty"`
 }
 
-func ResolveSessionConfig(cfg *agent.AgentConfig) *SessionConfig {
+// ResolveOptions contains optional overrides for session config resolution.
+type ResolveOptions struct {
+	MaxIterationsOverride int // CLI flag override; 0 means not set
+}
+
+func ResolveSessionConfig(cfg *agent.AgentConfig, opts ...ResolveOptions) *SessionConfig {
 	if cfg == nil {
 		return nil
+	}
+
+	var resolveOpts ResolveOptions
+	if len(opts) > 0 {
+		resolveOpts = opts[0]
 	}
 
 	sessionCfg := &SessionConfig{
@@ -67,9 +78,16 @@ func ResolveSessionConfig(cfg *agent.AgentConfig) *SessionConfig {
 	}
 	if cfg.Runtime == runtimeinfo.NativeRuntime {
 		sessionCfg.RuntimeConfig.EnabledTools = NativeToolNames()
+		// Priority: CLI flag > env var > oc-agent.yaml > hardcoded default
 		sessionCfg.RuntimeConfig.MaxIterations = defaultMaxIterations
 		if cfg.MaxIterations > 0 {
 			sessionCfg.RuntimeConfig.MaxIterations = cfg.MaxIterations
+		}
+		if v, err := strconv.Atoi(os.Getenv("TOC_MAX_ITERATIONS")); err == nil && v > 0 {
+			sessionCfg.RuntimeConfig.MaxIterations = v
+		}
+		if resolveOpts.MaxIterationsOverride > 0 {
+			sessionCfg.RuntimeConfig.MaxIterations = resolveOpts.MaxIterationsOverride
 		}
 		sessionCfg.RuntimeConfig.CompactionTriggerChars = 800000
 		sessionCfg.RuntimeConfig.CompactionKeepRecent = 12

--- a/internal/runtime/session_config_test.go
+++ b/internal/runtime/session_config_test.go
@@ -69,6 +69,73 @@ func TestSaveAndLoadSessionConfig(t *testing.T) {
 	}
 }
 
+func TestResolveSessionConfig_MaxIterations_Default(t *testing.T) {
+	cfg := ResolveSessionConfig(&agent.AgentConfig{
+		Name:    "test-agent",
+		Runtime: runtimeinfo.NativeRuntime,
+		Model:   "openai/gpt-4o-mini",
+		AllowCustomNativeModel: true,
+	})
+	if cfg.RuntimeConfig.MaxIterations != defaultMaxIterations {
+		t.Fatalf("MaxIterations = %d, want %d", cfg.RuntimeConfig.MaxIterations, defaultMaxIterations)
+	}
+}
+
+func TestResolveSessionConfig_MaxIterations_AgentYAML(t *testing.T) {
+	cfg := ResolveSessionConfig(&agent.AgentConfig{
+		Name:          "test-agent",
+		Runtime:       runtimeinfo.NativeRuntime,
+		Model:         "openai/gpt-4o-mini",
+		MaxIterations: 50,
+		AllowCustomNativeModel: true,
+	})
+	if cfg.RuntimeConfig.MaxIterations != 50 {
+		t.Fatalf("MaxIterations = %d, want 50", cfg.RuntimeConfig.MaxIterations)
+	}
+}
+
+func TestResolveSessionConfig_MaxIterations_EnvVar(t *testing.T) {
+	t.Setenv("TOC_MAX_ITERATIONS", "100")
+	cfg := ResolveSessionConfig(&agent.AgentConfig{
+		Name:          "test-agent",
+		Runtime:       runtimeinfo.NativeRuntime,
+		Model:         "openai/gpt-4o-mini",
+		MaxIterations: 50,
+		AllowCustomNativeModel: true,
+	})
+	if cfg.RuntimeConfig.MaxIterations != 100 {
+		t.Fatalf("MaxIterations = %d, want 100 (env should override agent yaml)", cfg.RuntimeConfig.MaxIterations)
+	}
+}
+
+func TestResolveSessionConfig_MaxIterations_CLIOverride(t *testing.T) {
+	t.Setenv("TOC_MAX_ITERATIONS", "100")
+	cfg := ResolveSessionConfig(&agent.AgentConfig{
+		Name:          "test-agent",
+		Runtime:       runtimeinfo.NativeRuntime,
+		Model:         "openai/gpt-4o-mini",
+		MaxIterations: 50,
+		AllowCustomNativeModel: true,
+	}, ResolveOptions{MaxIterationsOverride: 200})
+	if cfg.RuntimeConfig.MaxIterations != 200 {
+		t.Fatalf("MaxIterations = %d, want 200 (CLI should override env and agent yaml)", cfg.RuntimeConfig.MaxIterations)
+	}
+}
+
+func TestResolveSessionConfig_MaxIterations_InvalidEnvIgnored(t *testing.T) {
+	t.Setenv("TOC_MAX_ITERATIONS", "notanumber")
+	cfg := ResolveSessionConfig(&agent.AgentConfig{
+		Name:          "test-agent",
+		Runtime:       runtimeinfo.NativeRuntime,
+		Model:         "openai/gpt-4o-mini",
+		MaxIterations: 50,
+		AllowCustomNativeModel: true,
+	})
+	if cfg.RuntimeConfig.MaxIterations != 50 {
+		t.Fatalf("MaxIterations = %d, want 50 (invalid env should be ignored)", cfg.RuntimeConfig.MaxIterations)
+	}
+}
+
 func TestLoadSessionConfigInWorkspace_Missing(t *testing.T) {
 	_, err := LoadSessionConfigInWorkspace(t.TempDir(), "missing")
 	if !os.IsNotExist(err) {

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -31,7 +31,8 @@ type SpawnResult struct {
 
 // SpawnOptions contains optional parameters for SpawnSession.
 type SpawnOptions struct {
-	Prompt string // If set, run non-interactively with this prompt
+	Prompt        string // If set, run non-interactively with this prompt
+	MaxIterations int    // CLI override for max tool iterations; 0 means use default
 }
 
 func SpawnSession(cfg *agent.AgentConfig, opts ...SpawnOptions) (*SpawnResult, error) {
@@ -39,7 +40,9 @@ func SpawnSession(cfg *agent.AgentConfig, opts ...SpawnOptions) (*SpawnResult, e
 	if len(opts) > 0 {
 		spawnOpts = opts[0]
 	}
-	sessionCfg := runtime.ResolveSessionConfig(cfg)
+	sessionCfg := runtime.ResolveSessionConfig(cfg, runtime.ResolveOptions{
+		MaxIterationsOverride: spawnOpts.MaxIterations,
+	})
 	if err := runtime.ValidateSessionConfig(sessionCfg); err != nil {
 		return nil, err
 	}
@@ -222,12 +225,15 @@ type SubSpawnOpts struct {
 	ParentSessionID string
 	Prompt          string
 	WorkspaceDir    string // absolute path to the toc workspace
+	MaxIterations   int    // CLI override for max tool iterations; 0 means use default
 }
 
 // SpawnSubSession spawns a non-interactive sub-agent session in the background.
 // Output is captured to toc-output.txt in the session workspace.
 func SpawnSubSession(cfg *agent.AgentConfig, opts SubSpawnOpts) (*SpawnResult, error) {
-	sessionCfg := runtime.ResolveSessionConfig(cfg)
+	sessionCfg := runtime.ResolveSessionConfig(cfg, runtime.ResolveOptions{
+		MaxIterationsOverride: opts.MaxIterations,
+	})
 	if err := runtime.ValidateSessionConfig(sessionCfg); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Makes the native runtime's max tool iterations configurable via three layers with clear priority: `--max-iterations` CLI flag > `TOC_MAX_ITERATIONS` env var > `max_iterations` in oc-agent.yaml > hardcoded default (24)
- Adds the `--max-iterations` flag to both `toc agent spawn` and `toc runtime spawn` commands
- Threads the override through `SpawnOptions`/`SubSpawnOpts` into `ResolveSessionConfig`

## Test plan
- [x] 5 new unit tests covering each priority level and edge cases (invalid env var)
- [x] All existing tests pass (`go test ./... -short`)
- [ ] Manual: `toc agent spawn implementer --prompt "..." --max-iterations 50` respects the flag
- [ ] Manual: `TOC_MAX_ITERATIONS=100 toc agent spawn implementer --prompt "..."` respects the env var
- [ ] Manual: Setting `max_iterations: 80` in oc-agent.yaml is picked up when no flag/env is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)