### PR TITLE
feat: add Exa extract action for structured web page extraction

### DIFF
--- a/internal/integration/exa.go
+++ b/internal/integration/exa.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -25,6 +26,8 @@ func BuildExaRequestBody(action string, params map[string]string) map[string]int
 		"excludeText":    true,
 		"ids":            true,
 	}
+	// JSON params (JSON string → parsed object)
+	jsonParams := map[string]bool{"schema": true}
 	// Boolean params
 	boolParams := map[string]bool{"moderation": true}
 
@@ -38,6 +41,13 @@ func BuildExaRequestBody(action string, params map[string]string) map[string]int
 			}
 		case arrayParams[k]:
 			body[k] = splitCSV(v)
+		case jsonParams[k]:
+			var obj interface{}
+			if err := json.Unmarshal([]byte(v), &obj); err == nil {
+				body[k] = obj
+			} else {
+				body[k] = v
+			}
 		case boolParams[k]:
 			body[k] = v == "true"
 		default:
@@ -61,6 +71,22 @@ func BuildExaRequestBody(action string, params map[string]string) map[string]int
 			body["contents"] = map[string]interface{}{
 				"text": true,
 			}
+		}
+	}
+
+	// For extract, nest schema and query into contents.summary
+	if action == "extract" {
+		summary := map[string]interface{}{}
+		if schema, ok := body["schema"]; ok {
+			summary["schema"] = schema
+			delete(body, "schema")
+		}
+		if query, ok := body["query"]; ok {
+			summary["query"] = query
+			delete(body, "query")
+		}
+		body["contents"] = map[string]interface{}{
+			"summary": summary,
 		}
 	}
 

--- a/internal/integration/exa_load_test.go
+++ b/internal/integration/exa_load_test.go
@@ -15,10 +15,10 @@ func TestLoadExaDefinition(t *testing.T) {
 	if def.Auth.Method != "api_key" {
 		t.Errorf("expected auth method 'api_key', got: %s", def.Auth.Method)
 	}
-	if len(def.Actions) != 3 {
-		t.Errorf("expected 3 actions, got: %d", len(def.Actions))
+	if len(def.Actions) != 4 {
+		t.Errorf("expected 4 actions, got: %d", len(def.Actions))
 	}
-	for _, name := range []string{"search", "find_similar", "get_contents"} {
+	for _, name := range []string{"search", "find_similar", "get_contents", "extract"} {
 		if _, ok := def.Actions[name]; !ok {
 			t.Errorf("expected action '%s'", name)
 		}

--- a/internal/integration/exa_test.go
+++ b/internal/integration/exa_test.go
@@ -116,6 +116,85 @@ func TestBuildExaRequestBody_GetContents(t *testing.T) {
 	}
 }
 
+func TestBuildExaRequestBody_Extract(t *testing.T) {
+	params := map[string]string{
+		"ids":    "https://example.com/page1, https://example.com/page2",
+		"schema": `{"type":"object","properties":{"title":{"type":"string"},"price":{"type":"number"}},"required":["title"]}`,
+		"query":  "product details",
+	}
+
+	body := BuildExaRequestBody("extract", params)
+
+	// ids should be split into array
+	ids, ok := body["ids"].([]string)
+	if !ok {
+		t.Fatalf("expected ids to be []string, got: %T", body["ids"])
+	}
+	if len(ids) != 2 {
+		t.Errorf("expected 2 ids, got: %d", len(ids))
+	}
+
+	// schema and query should be removed from top level
+	if _, ok := body["schema"]; ok {
+		t.Error("schema should not be at top level")
+	}
+	if _, ok := body["query"]; ok {
+		t.Error("query should not be at top level")
+	}
+
+	// contents.summary should contain the schema and query
+	contents, ok := body["contents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected contents to be a map, got: %T", body["contents"])
+	}
+	summary, ok := contents["summary"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected contents.summary to be a map, got: %T", contents["summary"])
+	}
+
+	// schema should be parsed JSON, not a string
+	schema, ok := summary["schema"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected schema to be parsed JSON object, got: %T", summary["schema"])
+	}
+	if schema["type"] != "object" {
+		t.Errorf("expected schema.type to be 'object', got: %v", schema["type"])
+	}
+
+	// query should be passed through
+	if summary["query"] != "product details" {
+		t.Errorf("expected summary.query to be 'product details', got: %v", summary["query"])
+	}
+}
+
+func TestBuildExaRequestBody_ExtractNoQuery(t *testing.T) {
+	params := map[string]string{
+		"ids":    "https://example.com/page1",
+		"schema": `{"type":"object","properties":{"name":{"type":"string"}}}`,
+	}
+
+	body := BuildExaRequestBody("extract", params)
+
+	contents, ok := body["contents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected contents map, got: %T", body["contents"])
+	}
+	summary, ok := contents["summary"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected summary map, got: %T", contents["summary"])
+	}
+
+	// query should not be present
+	if _, ok := summary["query"]; ok {
+		t.Error("expected no query in summary when not provided")
+	}
+
+	// schema should still be there
+	if _, ok := summary["schema"]; !ok {
+		t.Error("expected schema in summary")
+	}
+}
+
 func TestBuildExaRequestBody_InvalidNumResults(t *testing.T) {
 	params := map[string]string{
 		"query":      "test",

--- a/registry/integrations/exa/integration.yaml
+++ b/registry/integrations/exa/integration.yaml
@@ -96,3 +96,26 @@ actions:
       - results[].title
       - results[].url
       - results[].text
+
+  extract:
+    description: Extract structured data from web pages using a JSON schema — provide URLs and a schema to get back only the fields you need
+    scopes:
+      "*": any URL
+    params:
+      - name: ids
+        required: true
+      - name: schema
+        required: true
+      - name: query
+        required: false
+    method: POST
+    endpoint: https://api.exa.ai/contents
+    auth_header: "x-api-key: {{token}}"
+    body_format: json
+    rate_limit:
+      max: 30
+      window: 60s
+    returns:
+      - results[].title
+      - results[].url
+      - results[].summary


### PR DESCRIPTION
## Summary
- Adds a new `extract` action to the Exa integration that lets agents extract structured data from web pages using a JSON schema
- The agent provides URLs (`ids`), a JSON `schema` defining desired fields, and an optional `query` to guide extraction
- Under the hood, maps flat params into Exa's `contents.summary.schema` API structure with proper JSON parsing and nesting
- Includes tests for the new action (with/without query) and updates the load test

## Test plan
- [x] `TestBuildExaRequestBody_Extract` — verifies schema parsing, query nesting, and top-level cleanup
- [x] `TestBuildExaRequestBody_ExtractNoQuery` — verifies extract works without optional query
- [x] `TestLoadExaDefinition` — verifies the YAML loads with 4 actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)