### PR TITLE
feat: first-class skill support in toc-native (agentskills.io spec)

### DIFF
--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -10,12 +10,14 @@ import (
 	"os/signal"
 	"path/filepath"
 	rdebug "runtime/debug"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/tiny-oc/toc/internal/runtimeinfo"
 	"github.com/tiny-oc/toc/internal/session"
+	"github.com/tiny-oc/toc/internal/skill"
 	"github.com/tiny-oc/toc/internal/ui"
 )
 
@@ -170,6 +172,22 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 			return finalizeNativeSession(client, state, sessionCfg, toolSpecs, profile, toolCtx, stdout, false)
 		}
 
+		// Expand skill slash commands: /skill-name [optional args]
+		// Matches any /name where a SKILL.md exists in .toc-native/skills/<name>/.
+		if strings.HasPrefix(line, "/") {
+			skillCmd := strings.TrimPrefix(line, "/")
+			skillName, skillArgs, _ := strings.Cut(skillCmd, " ")
+			skillArgs = strings.TrimSpace(skillArgs)
+			skillMDPath := filepath.Join(toolCtx.SessionDir, ".toc-native", "skills", skillName, "SKILL.md")
+			if _, statErr := os.Stat(skillMDPath); statErr == nil {
+				if skillArgs != "" {
+					line = fmt.Sprintf("Use the `%s` skill for this task: %s", skillName, skillArgs)
+				} else {
+					line = fmt.Sprintf("Use the `%s` skill.", skillName)
+				}
+			}
+		}
+
 		if err := runNativePrompt(client, state, toolSpecs, profile, line, toolCtx, stdout, false); err != nil {
 			// If a prompt fails, still finalize rather than bailing out
 			// without running post-session hooks.
@@ -295,13 +313,21 @@ func ensureSystemPrompt(state *State) error {
 	}
 	promptPath := filepath.Join(state.SessionDir, ".toc-native", "system-prompt.md")
 	data, err := os.ReadFile(promptPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	content := strings.TrimSpace(string(data))
+
+	// Append skill catalog if any skills are provisioned for this session.
+	skillsDir := filepath.Join(state.SessionDir, ".toc-native", "skills")
+	if catalog := buildSkillCatalog(skillsDir); catalog != "" {
+		if content != "" {
+			content = content + "\n\n" + catalog
+		} else {
+			content = catalog
+		}
+	}
+
 	if content == "" {
 		return nil
 	}
@@ -311,6 +337,56 @@ func ensureSystemPrompt(state *State) error {
 		CacheControl: &cacheControl{Type: "ephemeral"},
 	}}, state.Messages...)
 	return nil
+}
+
+// buildSkillCatalog scans skillsDir for provisioned skills and returns an XML
+// catalog string for injection into the system prompt. Returns "" if no skills
+// are found or the directory doesn't exist.
+func buildSkillCatalog(skillsDir string) string {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return ""
+	}
+
+	type skillEntry struct {
+		name        string
+		description string
+	}
+	var skills []skillEntry
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dirName := e.Name()
+		meta, err := skill.ParseSkillMD(filepath.Join(skillsDir, dirName, "SKILL.md"))
+		if err != nil || meta.Description == "" {
+			continue // skip malformed or undescribed skills
+		}
+		// Use the directory name for activation (what the Skill tool expects),
+		// description from frontmatter for context.
+		skills = append(skills, skillEntry{name: dirName, description: meta.Description})
+	}
+	if len(skills) == 0 {
+		return ""
+	}
+	sort.Slice(skills, func(i, j int) bool { return skills[i].name < skills[j].name })
+
+	var b strings.Builder
+	b.WriteString("The following skills are available for this session. When a task matches a skill's description, use the Skill tool with the skill's name to load its full instructions.\n\n")
+	b.WriteString("<available_skills>\n")
+	for _, s := range skills {
+		fmt.Fprintf(&b, "  <skill name=%q>%s</skill>\n", s.name, skillXMLEscape(s.description))
+	}
+	b.WriteString("</available_skills>")
+	return b.String()
+}
+
+// skillXMLEscape escapes characters that are unsafe inside XML text content.
+func skillXMLEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
 }
 
 func runNativePrompt(client *openRouterClient, state *State, toolSpecs []NativeToolSpec, profile runtimeinfo.NativeModelProfile, prompt string, toolCtx nativeToolContext, stdout io.Writer, detached bool) error {

--- a/internal/runtime/native_test.go
+++ b/internal/runtime/native_test.go
@@ -122,6 +122,140 @@ func TestSaveAndLoadState(t *testing.T) {
 	}
 }
 
+func TestBuildSkillCatalog(t *testing.T) {
+	dir := t.TempDir()
+
+	// Empty dir → empty catalog.
+	if got := buildSkillCatalog(dir); got != "" {
+		t.Fatalf("expected empty catalog for empty dir, got %q", got)
+	}
+
+	// Non-existent dir → empty catalog.
+	if got := buildSkillCatalog(filepath.Join(dir, "nonexistent")); got != "" {
+		t.Fatalf("expected empty catalog for missing dir, got %q", got)
+	}
+
+	// One valid skill.
+	skillDir := filepath.Join(dir, "commit")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillMD := "---\nname: commit\ndescription: Generate a conventional commit message and create a commit.\n---\n\nInstructions here.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillMD), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog := buildSkillCatalog(dir)
+	if catalog == "" {
+		t.Fatal("expected non-empty catalog")
+	}
+	if !strings.Contains(catalog, `name="commit"`) {
+		t.Errorf("catalog missing skill name: %q", catalog)
+	}
+	if !strings.Contains(catalog, "conventional commit") {
+		t.Errorf("catalog missing description: %q", catalog)
+	}
+	if !strings.Contains(catalog, "<available_skills>") {
+		t.Errorf("catalog missing XML wrapper: %q", catalog)
+	}
+
+	// Skill with XML-special characters in description is escaped.
+	specialDir := filepath.Join(dir, "special")
+	if err := os.MkdirAll(specialDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	specialMD := "---\nname: special\ndescription: Use when code has <errors> & warnings.\n---\n"
+	if err := os.WriteFile(filepath.Join(specialDir, "SKILL.md"), []byte(specialMD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	catalog2 := buildSkillCatalog(dir)
+	if !strings.Contains(catalog2, "&lt;errors&gt;") {
+		t.Errorf("catalog did not escape XML in description: %q", catalog2)
+	}
+	if !strings.Contains(catalog2, "&amp;") {
+		t.Errorf("catalog did not escape & in description: %q", catalog2)
+	}
+
+	// Skill without description is skipped.
+	nodescDir := filepath.Join(dir, "nodesc")
+	if err := os.MkdirAll(nodescDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nodescDir, "SKILL.md"), []byte("---\nname: nodesc\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	catalog3 := buildSkillCatalog(dir)
+	if strings.Contains(catalog3, `name="nodesc"`) {
+		t.Errorf("catalog should skip skill with no description: %q", catalog3)
+	}
+}
+
+func TestEnsureSystemPromptInjectsSkillCatalog(t *testing.T) {
+	sessionDir := t.TempDir()
+	nativeDir := filepath.Join(sessionDir, ".toc-native")
+	skillsDir := filepath.Join(nativeDir, "skills")
+
+	if err := os.MkdirAll(nativeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nativeDir, "system-prompt.md"), []byte("You are an agent.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No skills yet — system prompt alone.
+	state := &State{SessionDir: sessionDir}
+	if err := ensureSystemPrompt(state); err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 1 || state.Messages[0].Role != "system" {
+		t.Fatalf("expected system message, got %+v", state.Messages)
+	}
+	if strings.Contains(state.Messages[0].Content, "available_skills") {
+		t.Errorf("catalog should not appear when no skills present")
+	}
+
+	// Add a skill — catalog should appear on next fresh state.
+	if err := os.MkdirAll(filepath.Join(skillsDir, "commit"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillMD := "---\nname: commit\ndescription: Create a git commit.\n---\nInstructions.\n"
+	if err := os.WriteFile(filepath.Join(skillsDir, "commit", "SKILL.md"), []byte(skillMD), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state2 := &State{SessionDir: sessionDir}
+	if err := ensureSystemPrompt(state2); err != nil {
+		t.Fatal(err)
+	}
+	content := state2.Messages[0].Content
+	if !strings.Contains(content, "You are an agent.") {
+		t.Errorf("system prompt missing base content: %q", content)
+	}
+	if !strings.Contains(content, "<available_skills>") {
+		t.Errorf("system prompt missing skill catalog: %q", content)
+	}
+	if !strings.Contains(content, `name="commit"`) {
+		t.Errorf("system prompt missing skill name: %q", content)
+	}
+
+	// No system-prompt.md but skills present — catalog becomes the system prompt.
+	sessionDir3 := t.TempDir()
+	skillsDir3 := filepath.Join(sessionDir3, ".toc-native", "skills", "review")
+	if err := os.MkdirAll(skillsDir3, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir3, "SKILL.md"), []byte("---\nname: review\ndescription: Review code.\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	state3 := &State{SessionDir: sessionDir3}
+	if err := ensureSystemPrompt(state3); err != nil {
+		t.Fatal(err)
+	}
+	if len(state3.Messages) != 1 || !strings.Contains(state3.Messages[0].Content, "available_skills") {
+		t.Errorf("expected skill-only system prompt, got %+v", state3.Messages)
+	}
+}
+
 func TestNativeParseSessionLog(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/runtime/native_tool_registry.go
+++ b/internal/runtime/native_tool_registry.go
@@ -189,17 +189,17 @@ Anti-patterns:
 		},
 		{
 			Name: "Skill",
-			Description: `Load the instructions for a named skill that has been provisioned in this session.
+			Description: `Load the full instructions for a named skill provisioned in this session.
 
-Skills are pre-configured instruction sets (SKILL.md files) that provide specialized knowledge or workflows. Use this tool when a task matches a known skill — it returns the skill's full instructions so you can follow them.
+Available skills are listed in the system prompt under <available_skills>. When a task matches a skill's description, call this tool with the skill's name to load its complete instructions, then follow them.
 
 Parameters:
-- skill (required): The name of the skill to load. This must match a skill directory under .toc-native/skills/ in the session workspace.
+- skill (required): The name of the skill to load, as listed in the system prompt.
 
 Output: The full content of the skill's SKILL.md file (truncated at 64KB). Returns an error if the skill does not exist.
 
 Anti-patterns:
-- Do NOT guess skill names — if you are unsure what skills are available, check the session context or ask the user.
+- Do NOT guess skill names — only use names listed in <available_skills>.
 - Do NOT invoke a skill that is already loaded in the current conversation — follow its instructions directly instead of loading it again.`,
 			Parameters: map[string]interface{}{
 				"type": "object",


### PR DESCRIPTION
## Summary

- **Skill catalog in system prompt**: `ensureSystemPrompt` now scans `.toc-native/skills/` and injects an `<available_skills>` XML block so the model knows what skills are available and when to use them — implementing the progressive disclosure tier 1 from the [agentskills.io spec](https://agentskills.io/specification)
- **Slash command expansion**: The interactive loop now intercepts `/skill-name [args]` and expands it into a prompt that activates the skill via the Skill tool, matching the spec's recommended UX pattern
- **Skill tool description updated**: References `<available_skills>` in the system prompt instead of the vague "check session context"

## Details

Previously, toc-native had a `Skill` tool but the model had no way to know what skills were available — the tool description said "don't guess skill names, check the session context" but the session context contained no skill listing.

Now, when `ensureSystemPrompt` runs at session startup, it:
1. Reads the base system prompt from `.toc-native/system-prompt.md`
2. Scans `.toc-native/skills/` for provisioned skills (already copied there at spawn time)
3. Appends an XML catalog with name + description per skill
4. If no skills exist, nothing changes

The catalog format follows the official [agentskills.io specification](https://agentskills.io/client-implementation/adding-skills-support):

```xml
The following skills are available for this session. When a task matches a skill's description, use the Skill tool with the skill's name to load its full instructions.

<available_skills>
  <skill name="commit">Generate a conventional commit message and create a commit.</skill>
  <skill name="review">Review code for quality and security issues.</skill>
</available_skills>
```

## Test plan

- [x] `TestBuildSkillCatalog` — covers empty dir, valid skill, XML escaping, skill without description
- [x] `TestEnsureSystemPromptInjectsSkillCatalog` — covers catalog injection, no-skills case, skills-only system prompt
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)