### PR TITLE
Add native sub-agent completion notifications

### DIFF
--- a/cmd/runtime_notify_subagent.go
+++ b/cmd/runtime_notify_subagent.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tiny-oc/toc/internal/runtime"
+	"github.com/tiny-oc/toc/internal/session"
+)
+
+var (
+	notifyWorkspace     string
+	notifyParentSession string
+	notifySessionID     string
+	notifyAgent         string
+	notifyPromptFile    string
+	notifyOutputFile    string
+	notifyExitCodeFile  string
+)
+
+func init() {
+	notifySubAgentCmd.Flags().StringVar(&notifyWorkspace, "workspace", "", "Workspace path")
+	notifySubAgentCmd.Flags().StringVar(&notifyParentSession, "parent-session-id", "", "Parent session ID")
+	notifySubAgentCmd.Flags().StringVar(&notifySessionID, "session-id", "", "Sub-agent session ID")
+	notifySubAgentCmd.Flags().StringVar(&notifyAgent, "agent", "", "Sub-agent agent name")
+	notifySubAgentCmd.Flags().StringVar(&notifyPromptFile, "prompt-file", "", "Path to the sub-agent prompt file")
+	notifySubAgentCmd.Flags().StringVar(&notifyOutputFile, "output-file", "", "Path to the final sub-agent output file")
+	notifySubAgentCmd.Flags().StringVar(&notifyExitCodeFile, "exit-code-file", "", "Path to the sub-agent exit code file")
+	rootCmd.AddCommand(notifySubAgentCmd)
+}
+
+var notifySubAgentCmd = &cobra.Command{
+	Use:          "__notify-subagent-complete",
+	Short:        "Internal sub-agent completion notifier",
+	Hidden:       true,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if notifyWorkspace == "" || notifyParentSession == "" || notifySessionID == "" || notifyAgent == "" {
+			return fmt.Errorf("missing required notification flags")
+		}
+
+		prompt, err := readOptionalFile(notifyPromptFile)
+		if err != nil {
+			return err
+		}
+		output, err := readOptionalFile(notifyOutputFile)
+		if err != nil {
+			return err
+		}
+		exitCode, err := readExitCodeFile(notifyExitCodeFile)
+		if err != nil {
+			return err
+		}
+
+		status := session.StatusCompletedOK
+		if exitCode != 0 {
+			status = session.StatusCompletedError
+		}
+
+		_, err = runtime.WriteSubAgentCompletionNotification(notifyWorkspace, notifyParentSession, runtime.SessionNotification{
+			SessionID: notifySessionID,
+			Agent:     notifyAgent,
+			Status:    status,
+			ExitCode:  exitCode,
+			Prompt:    prompt,
+			Output:    output,
+		})
+		return err
+	},
+}
+
+func readOptionalFile(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func readExitCodeFile(path string) (int, error) {
+	if strings.TrimSpace(path) == "" {
+		return 0, nil
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, err
+	}
+	return code, nil
+}

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -99,7 +99,11 @@ func (claudeProvider) LaunchDetached(opts DetachedOptions) error {
 	}
 
 	scriptPath := filepath.Join(opts.Dir, "toc-run.sh")
-	if err := os.WriteFile(scriptPath, []byte(BuildClaudeDetachedScript(opts, promptPath)), 0755); err != nil {
+	helperExe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(scriptPath, []byte(BuildClaudeDetachedScript(helperExe, opts, promptPath)), 0755); err != nil {
 		return err
 	}
 
@@ -117,7 +121,7 @@ func (claudeProvider) LaunchDetached(opts DetachedOptions) error {
 }
 
 // BuildClaudeDetachedScript builds the wrapper script for a detached Claude session.
-func BuildClaudeDetachedScript(opts DetachedOptions, promptPath string) string {
+func BuildClaudeDetachedScript(helperExecutable string, opts DetachedOptions, promptPath string) string {
 	args := "claude --dangerously-skip-permissions"
 	args += fmt.Sprintf(" -p \"$(cat %q)\"", promptPath)
 	if opts.Model != "" {
@@ -132,6 +136,11 @@ func BuildClaudeDetachedScript(opts DetachedOptions, promptPath string) string {
 	tmpOutputPath := opts.OutputPath + ".tmp"
 	pidPath := filepath.Join(opts.Dir, "toc-pid.txt")
 	exitCodePath := filepath.Join(opts.Dir, "toc-exit-code.txt")
+	notifyCommand := ""
+	if opts.ParentSessionID != "" {
+		notifyCommand = fmt.Sprintf("%q __notify-subagent-complete --workspace %q --parent-session-id %q --session-id %q --agent %q --prompt-file %q --output-file %q --exit-code-file %q >/dev/null 2>&1 || true\n",
+			helperExecutable, opts.Workspace, opts.ParentSessionID, opts.SessionID, opts.AgentName, promptPath, opts.OutputPath, exitCodePath)
+	}
 
 	return fmt.Sprintf(`#!/bin/sh
 echo $$ > %q
@@ -143,7 +152,8 @@ export TOC_SESSION_ID=%q
 TOC_EXIT=$?
 echo $TOC_EXIT > %q
 mv %q %q
-`, pidPath, opts.Dir, opts.Workspace, opts.AgentName, opts.SessionID, args, tmpOutputPath, exitCodePath, tmpOutputPath, opts.OutputPath)
+%s
+`, pidPath, opts.Dir, opts.Workspace, opts.AgentName, opts.SessionID, args, tmpOutputPath, exitCodePath, tmpOutputPath, opts.OutputPath, notifyCommand)
 }
 
 func (claudeProvider) ExpectedSessionLogPath(sess *session.Session) string {

--- a/internal/runtime/native.go
+++ b/internal/runtime/native.go
@@ -150,7 +150,11 @@ func (nativeProvider) LaunchDetached(opts DetachedOptions) error {
 	}
 
 	scriptPath := filepath.Join(opts.Dir, "toc-run.sh")
-	if err := os.WriteFile(scriptPath, []byte(BuildNativeDetachedScript(exe, opts, promptPath)), 0755); err != nil {
+	helperExe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(scriptPath, []byte(BuildNativeDetachedScript(exe, helperExe, opts, promptPath)), 0755); err != nil {
 		return err
 	}
 
@@ -167,7 +171,7 @@ func (nativeProvider) LaunchDetached(opts DetachedOptions) error {
 	return cmd.Process.Release()
 }
 
-func BuildNativeDetachedScript(executable string, opts DetachedOptions, promptPath string) string {
+func BuildNativeDetachedScript(executable, helperExecutable string, opts DetachedOptions, promptPath string) string {
 	tmpOutputPath := opts.OutputPath + ".tmp"
 	pidPath := filepath.Join(opts.Dir, "toc-pid.txt")
 	exitCodePath := filepath.Join(opts.Dir, "toc-exit-code.txt")
@@ -191,6 +195,12 @@ func BuildNativeDetachedScript(executable string, opts DetachedOptions, promptPa
 		}
 	}
 
+	notifyCommand := ""
+	if opts.ParentSessionID != "" {
+		notifyCommand = fmt.Sprintf("%q __notify-subagent-complete --workspace %q --parent-session-id %q --session-id %q --agent %q --prompt-file %q --output-file %q --exit-code-file %q >/dev/null 2>&1 || true\n",
+			helperExecutable, opts.Workspace, opts.ParentSessionID, opts.SessionID, opts.AgentName, promptPath, opts.OutputPath, exitCodePath)
+	}
+
 	return fmt.Sprintf(`#!/bin/sh
 echo $$ > %q
 cd %q
@@ -201,7 +211,8 @@ export TOC_SESSION_ID=%q
 TOC_EXIT=$?
 echo $TOC_EXIT > %q
 mv %q %q
-`, pidPath, opts.Dir, opts.Workspace, opts.AgentName, opts.SessionID, openRouterExport, command, tmpOutputPath, exitCodePath, tmpOutputPath, opts.OutputPath)
+%s
+`, pidPath, opts.Dir, opts.Workspace, opts.AgentName, opts.SessionID, openRouterExport, command, tmpOutputPath, exitCodePath, tmpOutputPath, opts.OutputPath, notifyCommand)
 }
 
 func nativeExecutable() (string, error) {

--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -87,10 +87,16 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 		if err != nil {
 			return err
 		}
+		if err := waitForSessionNotifications(client, state, toolSpecs, profile, toolCtx, stdout, opts.Mode == "detached"); err != nil {
+			return err
+		}
 		return finalizeNativeSession(client, state, sessionCfg, toolSpecs, profile, toolCtx, stdout, true)
 	}
 
 	if opts.Mode == "detached" {
+		if err := waitForSessionNotifications(client, state, toolSpecs, profile, toolCtx, stdout, true); err != nil {
+			return err
+		}
 		return finalizeNativeSession(client, state, sessionCfg, toolSpecs, profile, toolCtx, stdout, true)
 	}
 
@@ -114,6 +120,9 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 
 	reader := bufio.NewReader(stdin)
 	for {
+		if _, err := drainSessionNotifications(client, state, toolSpecs, profile, toolCtx, stdout, false); err != nil {
+			return err
+		}
 		if isTTY {
 			fmt.Fprint(stdout, ui.UserPromptPrefix(opts.Agent))
 		} else {
@@ -542,6 +551,75 @@ func runNativeLoop(client *openRouterClient, state *State, toolSpecs []NativeToo
 	}
 
 	return fmt.Errorf("native runtime exceeded max tool iterations")
+}
+
+func waitForSessionNotifications(client *openRouterClient, state *State, toolSpecs []NativeToolSpec, profile runtimeinfo.NativeModelProfile, toolCtx nativeToolContext, stdout io.Writer, detached bool) error {
+	for {
+		handled, err := drainSessionNotifications(client, state, toolSpecs, profile, toolCtx, stdout, detached)
+		if err != nil {
+			return err
+		}
+		if handled {
+			continue
+		}
+
+		active, err := HasActiveSubAgents(state.Workspace, state.SessionID)
+		if err != nil {
+			return err
+		}
+		if !active {
+			return nil
+		}
+
+		state.Status = "waiting"
+		if err := SaveStateInWorkspace(state.Workspace, state.SessionID, state); err != nil {
+			return err
+		}
+
+		notification, err := WaitForSessionNotification(state.Workspace, state.SessionID, 30*time.Second)
+		if err != nil {
+			return err
+		}
+		if notification == nil {
+			continue
+		}
+		if err := handleSessionNotification(client, state, toolSpecs, profile, toolCtx, stdout, detached, notification); err != nil {
+			return err
+		}
+	}
+}
+
+func drainSessionNotifications(client *openRouterClient, state *State, toolSpecs []NativeToolSpec, profile runtimeinfo.NativeModelProfile, toolCtx nativeToolContext, stdout io.Writer, detached bool) (bool, error) {
+	handled := false
+	for {
+		notification, err := PopSessionNotification(state.Workspace, state.SessionID)
+		if err != nil {
+			return handled, err
+		}
+		if notification == nil {
+			return handled, nil
+		}
+		if err := handleSessionNotification(client, state, toolSpecs, profile, toolCtx, stdout, detached, notification); err != nil {
+			return handled, err
+		}
+		handled = true
+	}
+}
+
+func handleSessionNotification(client *openRouterClient, state *State, toolSpecs []NativeToolSpec, profile runtimeinfo.NativeModelProfile, toolCtx nativeToolContext, stdout io.Writer, detached bool, notification *SessionNotification) error {
+	if notification == nil {
+		return nil
+	}
+
+	switch notification.Type {
+	case SessionNotificationTypeSubAgentDone:
+		if !detached {
+			fmt.Fprintf(stdout, "\n%s\n", ui.Dim(fmt.Sprintf("sub-agent %s finished, continuing...", notification.Agent)))
+		}
+		return runNativePrompt(client, state, toolSpecs, profile, SessionNotificationPrompt(*notification), toolCtx, stdout, detached)
+	default:
+		return nil
+	}
 }
 
 func finalizeNativeSession(client *openRouterClient, state *State, sessionCfg *SessionConfig, toolSpecs []NativeToolSpec, profile runtimeinfo.NativeModelProfile, toolCtx nativeToolContext, stdout io.Writer, detached bool) error {

--- a/internal/runtime/native_runner_test.go
+++ b/internal/runtime/native_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tiny-oc/toc/internal/runtimeinfo"
 	"github.com/tiny-oc/toc/internal/session"
@@ -281,6 +282,224 @@ func TestRunNativeSession_DetachedToolLoop(t *testing.T) {
 	}
 }
 
+func TestRunNativeSession_ContinuesAfterSubAgentNotification(t *testing.T) {
+	workDir := t.TempDir()
+	metaWorkspace := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(workDir, ".toc-native"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(metaWorkspace, ".toc", "agents", "native-parent")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "oc-agent.yaml"), []byte("runtime: toc-native\nname: native-parent\nmodel: openai/gpt-4o-mini\npermissions:\n  sub-agents:\n    cto: on\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".toc-native", "system-prompt.md"), []byte("You are an orchestrator.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveSessionConfigInWorkspace(metaWorkspace, "sess-native-parent", &SessionConfig{
+		Agent:   "native-parent",
+		Runtime: runtimeinfo.NativeRuntime,
+		Model:   "openai/gpt-4o-mini",
+		RuntimeConfig: SessionRuntimeOptions{
+			EnabledTools: NativeToolNames(),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch callCount {
+		case 1:
+			writeSSEChunk(t, w, map[string]interface{}{
+				"id":    "resp-sub-1",
+				"model": req.Model,
+				"choices": []map[string]interface{}{
+					{
+						"index": 0,
+						"delta": map[string]interface{}{
+							"role":    "assistant",
+							"content": "",
+							"tool_calls": []map[string]interface{}{
+								{
+									"index": 0,
+									"id":    "call-sub-1",
+									"type":  "function",
+									"function": map[string]interface{}{
+										"name":      "SubAgent",
+										"arguments": `{"action":"spawn","agent":"cto","prompt":"Review the architecture and report back"}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			writeSSEChunk(t, w, map[string]interface{}{
+				"id":    "resp-sub-1",
+				"model": req.Model,
+				"usage": map[string]interface{}{"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+				"choices": []map[string]interface{}{
+					{
+						"index":         0,
+						"delta":         map[string]interface{}{},
+						"finish_reason": "tool_calls",
+					},
+				},
+			})
+		case 2:
+			last := req.Messages[len(req.Messages)-1]
+			if last.Role != "tool" || last.ToolCallID != "call-sub-1" {
+				t.Fatalf("expected sub-agent tool result, got %#v", last)
+			}
+			writeSSEChunk(t, w, map[string]interface{}{
+				"id":    "resp-sub-2",
+				"model": req.Model,
+				"choices": []map[string]interface{}{
+					{
+						"index": 0,
+						"delta": map[string]interface{}{
+							"role":    "assistant",
+							"content": "Spawned cto and waiting for completion.",
+						},
+					},
+				},
+			})
+			writeSSEChunk(t, w, map[string]interface{}{
+				"id":    "resp-sub-2",
+				"model": req.Model,
+				"usage": map[string]interface{}{"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17},
+				"choices": []map[string]interface{}{
+					{
+						"index":         0,
+						"delta":         map[string]interface{}{},
+						"finish_reason": "stop",
+					},
+				},
+			})
+		case 3:
+			last := req.Messages[len(req.Messages)-1]
+			if last.Role != "user" || !strings.Contains(last.Content, "Sub-agent completion update.") {
+				t.Fatalf("expected sub-agent completion notification, got %#v", last)
+			}
+			if !strings.Contains(last.Content, "Agent: cto") || !strings.Contains(last.Content, "child delivered result") {
+				t.Fatalf("unexpected completion prompt %q", last.Content)
+			}
+			writeSSEChunk(t, w, map[string]interface{}{
+				"id":    "resp-sub-3",
+				"model": req.Model,
+				"choices": []map[string]interface{}{
+					{
+						"index": 0,
+						"delta": map[string]interface{}{
+							"role":    "assistant",
+							"content": "Integrated child result.",
+						},
+					},
+				},
+			})
+			writeSSEChunk(t, w, map[string]interface{}{
+				"id":    "resp-sub-3",
+				"model": req.Model,
+				"usage": map[string]interface{}{"prompt_tokens": 14, "completion_tokens": 6, "total_tokens": 20},
+				"choices": []map[string]interface{}{
+					{
+						"index":         0,
+						"delta":         map[string]interface{}{},
+						"finish_reason": "stop",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+		}
+
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_BASE_URL", server.URL)
+
+	spawnFunc := func(agentName, prompt, workspace, parentSessionID string) (*SubAgentSpawnResult, error) {
+		childWorkDir := t.TempDir()
+		if err := session.AddInWorkspace(workspace, session.Session{
+			ID:              "child-native-1",
+			Agent:           agentName,
+			Runtime:         DefaultRuntime,
+			MetadataDir:     MetadataDir(workspace, "child-native-1"),
+			CreatedAt:       time.Now(),
+			WorkspacePath:   childWorkDir,
+			Status:          session.StatusActive,
+			ParentSessionID: parentSessionID,
+			Prompt:          prompt,
+		}); err != nil {
+			return nil, err
+		}
+
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			_ = os.WriteFile(filepath.Join(childWorkDir, "toc-exit-code.txt"), []byte("0\n"), 0644)
+			_ = os.WriteFile(filepath.Join(childWorkDir, "toc-output.txt"), []byte("child delivered result\n"), 0644)
+			_, _ = WriteSubAgentCompletionNotification(workspace, parentSessionID, SessionNotification{
+				SessionID: "child-native-1",
+				Agent:     agentName,
+				Status:    session.StatusCompletedOK,
+				ExitCode:  0,
+				Prompt:    prompt,
+				Output:    "child delivered result\n",
+			})
+		}()
+
+		return &SubAgentSpawnResult{SessionID: "child-native-1"}, nil
+	}
+
+	var stdout bytes.Buffer
+	err := RunNativeSession(NativeRunOptions{
+		Mode:      "detached",
+		Dir:       workDir,
+		SessionID: "sess-native-parent",
+		Agent:     "native-parent",
+		Workspace: metaWorkspace,
+		Model:     "openai/gpt-4o-mini",
+		Prompt:    "Delegate the architecture review and continue when the result is ready.",
+		SpawnFunc: spawnFunc,
+	}, bytes.NewBuffer(nil), &stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := stdout.String(); got != "Spawned cto and waiting for completion.\nIntegrated child result.\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 model calls, got %d", callCount)
+	}
+
+	state, err := LoadStateInWorkspace(metaWorkspace, "sess-native-parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Status != "completed" {
+		t.Fatalf("state status = %q", state.Status)
+	}
+	last := state.Messages[len(state.Messages)-1]
+	if last.Role != "assistant" || last.Content != "Integrated child result." {
+		t.Fatalf("unexpected final message %#v", last)
+	}
+}
+
 func writeSSEChunk(t *testing.T, w http.ResponseWriter, payload map[string]interface{}) {
 	t.Helper()
 	data, err := json.Marshal(payload)
@@ -455,13 +674,13 @@ func TestRunNativeSession_RecoversInterruptedTurnOnResume(t *testing.T) {
 
 func TestAccumulateUsage(t *testing.T) {
 	tests := []struct {
-		name        string
-		state       *State
-		resp        *chatResponse
-		wantInput   int64
-		wantOutput  int64
-		wantCacheR  int64
-		wantCacheW  int64
+		name       string
+		state      *State
+		resp       *chatResponse
+		wantInput  int64
+		wantOutput int64
+		wantCacheR int64
+		wantCacheW int64
 	}{
 		{
 			name:  "nil state",

--- a/internal/runtime/provider.go
+++ b/internal/runtime/provider.go
@@ -60,14 +60,15 @@ type LaunchOptions struct {
 }
 
 type DetachedOptions struct {
-	Dir        string
-	Model      string
-	Prompt     string
-	Workspace  string
-	AgentName  string
-	SessionID  string
-	OutputPath string
-	Resume     bool
+	Dir             string
+	Model           string
+	Prompt          string
+	Workspace       string
+	AgentName       string
+	SessionID       string
+	ParentSessionID string
+	OutputPath      string
+	Resume          bool
 }
 
 // Provider owns runtime-specific process launch and observability behavior.

--- a/internal/runtime/session_notify.go
+++ b/internal/runtime/session_notify.go
@@ -1,0 +1,191 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tiny-oc/toc/internal/session"
+)
+
+const (
+	SessionNotificationVersion          = 1
+	SessionNotificationTypeSubAgentDone = "subagent.completed"
+	maxNotificationOutputBytes          = 16 * 1024
+)
+
+type SessionNotification struct {
+	Version         int       `json:"version"`
+	ID              string    `json:"id"`
+	Type            string    `json:"type"`
+	ParentSessionID string    `json:"parent_session_id"`
+	SessionID       string    `json:"session_id"`
+	Agent           string    `json:"agent"`
+	Status          string    `json:"status"`
+	ExitCode        int       `json:"exit_code,omitempty"`
+	Prompt          string    `json:"prompt,omitempty"`
+	Output          string    `json:"output,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+func sessionNotificationDir(workspace, sessionID string) string {
+	return filepath.Join(MetadataDir(workspace, sessionID), "notifications")
+}
+
+func WriteSessionNotification(workspace, sessionID string, notification SessionNotification) (string, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return "", fmt.Errorf("session notification requires a parent session ID")
+	}
+	if notification.ID == "" {
+		notification.ID = uuid.New().String()
+	}
+	if notification.Version == 0 {
+		notification.Version = SessionNotificationVersion
+	}
+	if notification.CreatedAt.IsZero() {
+		notification.CreatedAt = time.Now().UTC()
+	}
+
+	dir := sessionNotificationDir(workspace, sessionID)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+
+	filename := fmt.Sprintf("%020d-%s.json", notification.CreatedAt.UnixNano(), notification.ID)
+	finalPath := filepath.Join(dir, filename)
+	tmpPath := finalPath + ".tmp"
+
+	data, err := json.MarshalIndent(notification, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(tmpPath, append(data, '\n'), 0600); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return notification.ID, nil
+}
+
+func PopSessionNotification(workspace, sessionID string) (*SessionNotification, error) {
+	dir := sessionNotificationDir(workspace, sessionID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		files = append(files, entry.Name())
+	}
+	sort.Strings(files)
+
+	for _, name := range files {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		var notification SessionNotification
+		if err := json.Unmarshal(data, &notification); err != nil {
+			_ = os.Remove(path)
+			return nil, err
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		return &notification, nil
+	}
+
+	return nil, nil
+}
+
+func WaitForSessionNotification(workspace, sessionID string, timeout time.Duration) (*SessionNotification, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		notification, err := PopSessionNotification(workspace, sessionID)
+		if err != nil {
+			return nil, err
+		}
+		if notification != nil {
+			return notification, nil
+		}
+		if timeout > 0 && time.Now().After(deadline) {
+			return nil, nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func WriteSubAgentCompletionNotification(workspace, parentSessionID string, notification SessionNotification) (string, error) {
+	notification.Type = SessionNotificationTypeSubAgentDone
+	notification.ParentSessionID = parentSessionID
+	notification.Output = truncateNotificationOutput(notification.Output)
+	return WriteSessionNotification(workspace, parentSessionID, notification)
+}
+
+func HasActiveSubAgents(workspace, parentSessionID string) (bool, error) {
+	children, err := session.ListByParentInWorkspace(workspace, parentSessionID)
+	if err != nil {
+		return false, err
+	}
+	for _, child := range children {
+		if child.ResolvedStatus() == session.StatusActive {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func SessionNotificationPrompt(notification SessionNotification) string {
+	status := strings.TrimSpace(notification.Status)
+	if status == "" {
+		status = "completed"
+	}
+
+	var b strings.Builder
+	b.WriteString("Sub-agent completion update.\n\n")
+	b.WriteString(fmt.Sprintf("Agent: %s\n", notification.Agent))
+	b.WriteString(fmt.Sprintf("Session: %s\n", notification.SessionID))
+	b.WriteString(fmt.Sprintf("Status: %s\n", status))
+	if notification.ExitCode != 0 || status == session.StatusCompletedError {
+		b.WriteString(fmt.Sprintf("Exit code: %d\n", notification.ExitCode))
+	}
+	if strings.TrimSpace(notification.Prompt) != "" {
+		b.WriteString("\nOriginal task:\n")
+		b.WriteString(notification.Prompt)
+		b.WriteString("\n")
+	}
+	if strings.TrimSpace(notification.Output) != "" {
+		b.WriteString("\nOutput:\n")
+		b.WriteString(notification.Output)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nContinue the main task using this result.")
+	return b.String()
+}
+
+func truncateNotificationOutput(output string) string {
+	output = strings.TrimSpace(output)
+	if len(output) <= maxNotificationOutputBytes {
+		return output
+	}
+	return strings.TrimSpace(output[:maxNotificationOutputBytes]) + "\n...[truncated]"
+}

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -305,7 +305,7 @@ func SpawnSubSession(cfg *agent.AgentConfig, opts SubSpawnOpts) (*SpawnResult, e
 	if err := provider.LaunchDetached(runtime.DetachedOptions{
 		Dir: workDir, Model: sessionCfg.Model, Prompt: opts.Prompt,
 		Workspace: opts.WorkspaceDir, AgentName: sessionCfg.Agent,
-		SessionID: sessionID, OutputPath: outputPath,
+		SessionID: sessionID, ParentSessionID: opts.ParentSessionID, OutputPath: outputPath,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to launch sub-agent: %w", err)
 	}
@@ -378,7 +378,7 @@ func ResumeSubSession(s *session.Session, opts SubResumeOpts) (*SpawnResult, err
 	if err := provider.LaunchDetached(runtime.DetachedOptions{
 		Dir: s.WorkspacePath, Model: sessionCfg.Model, Prompt: resumePrompt,
 		Workspace: opts.WorkspaceDir, AgentName: s.Agent, SessionID: s.ID,
-		OutputPath: outputPath, Resume: true,
+		ParentSessionID: s.ParentSessionID, OutputPath: outputPath, Resume: true,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to launch resumed sub-agent: %w", err)
 	}

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -57,7 +57,7 @@ func TestIntegrationsSummary(t *testing.T) {
 				Permissions: agent.Permissions{
 					Integrations: map[string]agent.IntegrationPermissions{
 						"exa":   {{Mode: agent.PermOn, Capability: "search"}, {Mode: agent.PermOn, Capability: "find_similar"}, {Mode: agent.PermOn, Capability: "contents"}},
-						"slack":  {{Mode: agent.PermOn, Capability: "post:#eng"}},
+						"slack": {{Mode: agent.PermOn, Capability: "post:#eng"}},
 					},
 				},
 			},
@@ -80,7 +80,7 @@ func TestBuildDetachedScript_PIDTracking(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test prompt"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/workspace", AgentName: "agent",
 		SessionID: "session-123", OutputPath: filepath.Join(dir, "toc-output.txt"),
 	}, promptPath)
@@ -98,7 +98,7 @@ func TestBuildDetachedScript_ExitCodeCapture(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/ws", AgentName: "agent",
 		SessionID: "sess", OutputPath: filepath.Join(dir, "toc-output.txt"),
 	}, promptPath)
@@ -123,7 +123,7 @@ func TestBuildDetachedScript_EnvVars(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Model: "sonnet", Workspace: "/my/workspace",
 		AgentName: "test-agent", SessionID: "sess-456",
 		OutputPath: filepath.Join(dir, "toc-output.txt"),
@@ -145,7 +145,7 @@ func TestBuildDetachedScript_WithModel(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Model: "opus", Workspace: "/ws", AgentName: "agent",
 		SessionID: "sess", OutputPath: filepath.Join(dir, "toc-output.txt"),
 	}, promptPath)
@@ -160,7 +160,7 @@ func TestBuildDetachedScript_WithoutModel(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/ws", AgentName: "agent",
 		SessionID: "sess", OutputPath: filepath.Join(dir, "toc-output.txt"),
 	}, promptPath)
@@ -175,7 +175,7 @@ func TestBuildDetachedScript_Resume_UsesResumeFlag(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("resume prompt"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/ws", AgentName: "agent",
 		SessionID: "sess-789", OutputPath: filepath.Join(dir, "toc-output.txt"),
 		Resume: true,
@@ -203,7 +203,7 @@ func TestBuildDetachedScript_NoResume_NoResumeFlag(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/ws", AgentName: "agent",
 		SessionID: "sess", OutputPath: filepath.Join(dir, "toc-output.txt"),
 		Resume: false,
@@ -225,7 +225,7 @@ func TestBuildDetachedScript_SessionID(t *testing.T) {
 	promptPath := filepath.Join(dir, "toc-prompt.txt")
 	os.WriteFile(promptPath, []byte("test"), 0644)
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/ws", AgentName: "agent",
 		SessionID: "abc-123", OutputPath: filepath.Join(dir, "toc-output.txt"),
 	}, promptPath)
@@ -241,7 +241,7 @@ func TestBuildDetachedScript_AtomicRename(t *testing.T) {
 	os.WriteFile(promptPath, []byte("test"), 0644)
 	outputPath := filepath.Join(dir, "toc-output.txt")
 
-	script := runtime.BuildClaudeDetachedScript(runtime.DetachedOptions{
+	script := runtime.BuildClaudeDetachedScript("toc", runtime.DetachedOptions{
 		Dir: dir, Workspace: "/ws", AgentName: "agent",
 		SessionID: "sess", OutputPath: outputPath,
 	}, promptPath)


### PR DESCRIPTION
This adds a file-backed session notification inbox for parent sessions and emits sub-agent completion notifications from detached Claude and native child runs. The native runtime now waits for those notifications and automatically continues the parent session with the child result instead of requiring explicit polling. Detached launch plumbing now carries parent session IDs, and the runtime tests cover the new continuation flow. Verified with go test ./....