### PR TITLE
Add anthropic/claude-opus-4.6 to native model registry

### DIFF
--- a/internal/runtimeinfo/native_models.go
+++ b/internal/runtimeinfo/native_models.go
@@ -71,6 +71,16 @@ var nativeModelProfiles = []NativeModelProfile{
 		MaxOutputTokens:   32768,
 		ReservedBuffer:    8192,
 	},
+	{
+		ID:                "anthropic/claude-opus-4.6",
+		Label:             "Claude Opus 4.6",
+		Description:       "Anthropic flagship model for coding and agentic workflows with 1M context",
+		SupportsTools:     true,
+		SupportsStreaming: true,
+		ContextWindow:     1000000,
+		MaxOutputTokens:   128000,
+		ReservedBuffer:    8192,
+	},
 }
 
 func NativeProfiles() []NativeModelProfile {

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -41,6 +41,12 @@ var modelPricing = map[string]ModelPricing{
 		CacheReadPerToken:  1.75 / 1_000_000, // no cache discount listed
 		CacheWritePerToken: 1.75 / 1_000_000,
 	},
+	"anthropic/claude-opus-4.6": {
+		InputPerToken:      5.00 / 1_000_000,
+		OutputPerToken:     25.00 / 1_000_000,
+		CacheReadPerToken:  0.50 / 1_000_000,
+		CacheWritePerToken: 6.25 / 1_000_000,
+	},
 }
 
 // EstimateCost returns the estimated USD cost for the given token usage


### PR DESCRIPTION
## Summary
- Registers `anthropic/claude-opus-4.6` in the toc-native model profile set with 1M context window, 128k max output tokens, and 8k reserved buffer
- Adds OpenRouter pricing: $5.00/M input, $25.00/M output, $0.50/M cache read, $6.25/M cache write
- All specs sourced from the OpenRouter `/api/v1/models` endpoint

## Test plan
- [x] `go test ./internal/runtimeinfo/` — all pass
- [x] `go test ./internal/usage/` — all pass
- [x] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)