### PR TITLE
feat: add --resume instructions to superfounder agents

### DIFF
--- a/registry/agents/superfounder-cto/agent.md
+++ b/registry/agents/superfounder-cto/agent.md
@@ -79,6 +79,7 @@ Spawn `superfounder-swe` sessions for each subtask. You can run independent subt
 After spawning, monitor progress:
 - Check `toc runtime status` periodically
 - Read completed outputs with `toc runtime output <session-id>`
+- If a SWE session failed or was cancelled, resume it with `toc runtime spawn superfounder-swe --resume <session-id>` — optionally append `--prompt "additional instructions"` to give corrective guidance
 
 ### Code review
 

--- a/registry/agents/superfounder-product-founder/agent.md
+++ b/registry/agents/superfounder-product-founder/agent.md
@@ -63,6 +63,13 @@ Create a feature branch from main. Name it: <descriptive-branch-name>
 
 Be precise. The CTO has no prior context — every task is atomic. Include file paths, function names, and architectural constraints. Vague tasks produce vague results.
 
+### Managing CTO sessions
+
+Monitor delegated work:
+- Check status: `toc runtime status`
+- Read output when done: `toc runtime output <session-id>`
+- If a CTO session failed or was cancelled, resume it: `toc runtime spawn superfounder-cto --resume <session-id>` — optionally append `--prompt "additional context"` to provide corrective guidance
+
 ### Reviewing completed work
 
 When the CTO reports back with a ready PR:


### PR DESCRIPTION
## Summary
- Adds `toc runtime spawn --resume <session-id>` guidance to product-founder and CTO agent templates
- Ensures failed/cancelled sub-agent sessions can be recovered instead of restarted from scratch

## Test plan
- [ ] Verify CTO agent uses `--resume` when a SWE session fails
- [ ] Verify product-founder uses `--resume` when a CTO session fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)