### PR TITLE
Add TodoWrite support to toc-native

### DIFF
--- a/cmd/runtime_output.go
+++ b/cmd/runtime_output.go
@@ -105,6 +105,7 @@ func printOutput(jsonFlag, metaFlag bool, s *session.Session, status string, dat
 			"compaction_count": summaryIntField(summary, func(v *runtimeStateSummary) int { return v.CompactionCount }),
 			"last_error":       summaryField(summary, func(v *runtimeStateSummary) string { return v.LastError }),
 			"last_recovery":    summaryField(summary, func(v *runtimeStateSummary) string { return v.LastRecovery }),
+			"todos":            summaryTodos(summary),
 			"token_total":      summaryTokenField(summary),
 			"output":           string(data),
 		})
@@ -138,6 +139,12 @@ func printOutput(jsonFlag, metaFlag bool, s *session.Session, status string, dat
 			if summary.LastRecovery != "" {
 				fmt.Printf("  %s %s\n", ui.Bold("Last recovery:"), ui.Dim(summary.LastRecovery))
 			}
+			if todoLines := formatTodoLines(summary.Todos); len(todoLines) > 0 {
+				fmt.Printf("  %s\n", ui.Bold("Todos:"))
+				for _, line := range todoLines {
+					fmt.Printf("    %s %s\n", ui.Dim("•"), ui.Dim(line))
+				}
+			}
 		}
 		fmt.Println()
 	}
@@ -164,4 +171,11 @@ func summaryTokenField(summary *runtimeStateSummary) int64 {
 		return 0
 	}
 	return summary.Tokens.Total()
+}
+
+func summaryTodos(summary *runtimeStateSummary) []runtime.TodoItem {
+	if summary == nil {
+		return nil
+	}
+	return append([]runtime.TodoItem(nil), summary.Todos...)
 }

--- a/cmd/runtime_output_test.go
+++ b/cmd/runtime_output_test.go
@@ -31,6 +31,10 @@ func TestPrintOutput_WithMetaIncludesNativeState(t *testing.T) {
 		ResumeCount:     1,
 		CompactionCount: 2,
 		LastError:       "cancelled by parent",
+		Todos: []runtime.TodoItem{
+			{Content: "Finish migration", Status: "in_progress", Priority: "high"},
+			{Content: "Run tests", Status: "pending", Priority: "medium"},
+		},
 		Usage: runtime.TokenUsageSnapshot{
 			InputTokens:  10,
 			OutputTokens: 5,
@@ -45,7 +49,7 @@ func TestPrintOutput_WithMetaIncludesNativeState(t *testing.T) {
 		}
 	})
 
-	for _, want := range []string{"Session:", "Runtime:", "Model:", "Resumes:", "Compactions:", "Tokens:", "Last error:", "partial output"} {
+	for _, want := range []string{"Session:", "Runtime:", "Model:", "Resumes:", "Compactions:", "Tokens:", "Last error:", "Todos:", "Finish migration", "Run tests", "partial output"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected %q in output: %q", want, output)
 		}

--- a/cmd/runtime_state_helpers.go
+++ b/cmd/runtime_state_helpers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/tiny-oc/toc/internal/runtime"
@@ -17,8 +18,9 @@ type runtimeStateSummary struct {
 	LastError          string
 	LastRecovery       string
 	CrashInfo          *runtime.CrashInfo
+	Todos              []runtime.TodoItem
 	Tokens             usage.TokenUsage
-	LastRequestContext  int64 // input tokens from last API call (context pressure indicator)
+	LastRequestContext int64 // input tokens from last API call (context pressure indicator)
 }
 
 func loadRuntimeStateSummary(s *session.Session) (*runtimeStateSummary, error) {
@@ -43,6 +45,7 @@ func loadRuntimeStateSummary(s *session.Session) (*runtimeStateSummary, error) {
 		LastError:       state.LastError,
 		LastRecovery:    state.LastRecovery,
 		CrashInfo:       state.CrashInfo,
+		Todos:           append([]runtime.TodoItem(nil), state.Todos...),
 		Tokens: usage.TokenUsage{
 			InputTokens:  state.Usage.InputTokens,
 			OutputTokens: state.Usage.OutputTokens,
@@ -51,4 +54,15 @@ func loadRuntimeStateSummary(s *session.Session) (*runtimeStateSummary, error) {
 		},
 		LastRequestContext: state.LastRequestUsage.InputTokens,
 	}, nil
+}
+
+func formatTodoLines(todos []runtime.TodoItem) []string {
+	if len(todos) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(todos))
+	for _, todo := range todos {
+		lines = append(lines, fmt.Sprintf("[%s/%s] %s", todo.Status, todo.Priority, todo.Content))
+	}
+	return lines
 }

--- a/cmd/runtime_status.go
+++ b/cmd/runtime_status.go
@@ -43,24 +43,25 @@ var runtimeStatusCmd = &cobra.Command{
 }
 
 type statusJSON struct {
-	ID           string `json:"id"`
-	Name         string `json:"name,omitempty"`
-	Agent        string `json:"agent"`
-	Status       string `json:"status"`
-	Prompt       string `json:"prompt,omitempty"`
-	ExitCode     *int   `json:"exit_code,omitempty"`
-	Model        string `json:"model,omitempty"`
-	Runtime      string `json:"runtime,omitempty"`
-	RuntimeState string `json:"runtime_state,omitempty"`
-	ResumeCount  int    `json:"resume_count,omitempty"`
-	Recoveries   int    `json:"recovery_count,omitempty"`
-	Compactions  int    `json:"compactions,omitempty"`
-	LastError    string `json:"last_error,omitempty"`
-	LastRecovery string `json:"last_recovery,omitempty"`
-	TokenTotal        int64  `json:"token_total,omitempty"`
-	InputTokens       int64  `json:"input_tokens,omitempty"`
-	OutputTokens      int64  `json:"output_tokens,omitempty"`
-	LastRequestInput  int64  `json:"last_request_input,omitempty"`
+	ID               string             `json:"id"`
+	Name             string             `json:"name,omitempty"`
+	Agent            string             `json:"agent"`
+	Status           string             `json:"status"`
+	Prompt           string             `json:"prompt,omitempty"`
+	ExitCode         *int               `json:"exit_code,omitempty"`
+	Model            string             `json:"model,omitempty"`
+	Runtime          string             `json:"runtime,omitempty"`
+	RuntimeState     string             `json:"runtime_state,omitempty"`
+	ResumeCount      int                `json:"resume_count,omitempty"`
+	Recoveries       int                `json:"recovery_count,omitempty"`
+	Compactions      int                `json:"compactions,omitempty"`
+	LastError        string             `json:"last_error,omitempty"`
+	LastRecovery     string             `json:"last_recovery,omitempty"`
+	Todos            []runtime.TodoItem `json:"todos,omitempty"`
+	TokenTotal       int64              `json:"token_total,omitempty"`
+	InputTokens      int64              `json:"input_tokens,omitempty"`
+	OutputTokens     int64              `json:"output_tokens,omitempty"`
+	LastRequestInput int64              `json:"last_request_input,omitempty"`
 }
 
 func statusJSONForSession(s *session.Session) statusJSON {
@@ -83,6 +84,7 @@ func statusJSONForSession(s *session.Session) statusJSON {
 		sj.Compactions = summary.CompactionCount
 		sj.LastError = summary.LastError
 		sj.LastRecovery = summary.LastRecovery
+		sj.Todos = append([]runtime.TodoItem(nil), summary.Todos...)
 		sj.TokenTotal = summary.Tokens.Total()
 		sj.InputTokens = summary.Tokens.InputTokens
 		sj.OutputTokens = summary.Tokens.OutputTokens
@@ -196,6 +198,12 @@ func showSubAgentStatus(ctx *runtime.Context, sessionID string) error {
 		}
 		if summary.LastRecovery != "" {
 			fmt.Printf("  %s %s\n", ui.Bold("Last recovery:"), ui.Dim(summary.LastRecovery))
+		}
+		if todoLines := formatTodoLines(summary.Todos); len(todoLines) > 0 {
+			fmt.Printf("  %s\n", ui.Bold("Todos:"))
+			for _, line := range todoLines {
+				fmt.Printf("    %s %s\n", ui.Dim("•"), ui.Dim(line))
+			}
 		}
 	}
 	if s.Prompt != "" {

--- a/cmd/runtime_status_test.go
+++ b/cmd/runtime_status_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/tiny-oc/toc/internal/runtime"
+	"github.com/tiny-oc/toc/internal/runtimeinfo"
+	"github.com/tiny-oc/toc/internal/session"
+	"gopkg.in/yaml.v3"
+)
+
+func TestStatusJSONForSessionIncludesTodos(t *testing.T) {
+	sess := &session.Session{
+		ID:          "sess-status-json",
+		Agent:       "native-agent",
+		Runtime:     runtimeinfo.NativeRuntime,
+		MetadataDir: t.TempDir(),
+	}
+	if err := runtime.SaveState(sess, &runtime.State{
+		Runtime:   runtimeinfo.NativeRuntime,
+		SessionID: sess.ID,
+		Agent:     sess.Agent,
+		Model:     "openai/gpt-4o-mini",
+		Todos: []runtime.TodoItem{
+			{Content: "Implement TodoWrite", Status: "in_progress", Priority: "high"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := statusJSONForSession(sess)
+	if len(got.Todos) != 1 {
+		t.Fatalf("len(got.Todos) = %d, want 1", len(got.Todos))
+	}
+	if got.Todos[0].Content != "Implement TodoWrite" {
+		t.Fatalf("unexpected todos: %#v", got.Todos)
+	}
+}
+
+func TestShowSubAgentStatusDisplaysTodos(t *testing.T) {
+	color.NoColor = true
+	defer func() { color.NoColor = false }()
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, ".toc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadataDir := filepath.Join(workspace, ".toc", "sessions", "child-status")
+	sessions := session.SessionsFile{
+		Sessions: []session.Session{
+			{
+				ID:              "child-status",
+				Agent:           "native-agent",
+				Runtime:         runtimeinfo.NativeRuntime,
+				MetadataDir:     metadataDir,
+				CreatedAt:       time.Now(),
+				WorkspacePath:   t.TempDir(),
+				Status:          session.StatusCompletedOK,
+				ParentSessionID: "parent-status",
+			},
+		},
+	}
+	data, err := yaml.Marshal(&sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, ".toc", "sessions.yaml"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.SaveState(&session.Session{
+		ID:          "child-status",
+		MetadataDir: metadataDir,
+	}, &runtime.State{
+		Runtime:   runtimeinfo.NativeRuntime,
+		SessionID: "child-status",
+		Agent:     "native-agent",
+		Model:     "openai/gpt-4o-mini",
+		Todos: []runtime.TodoItem{
+			{Content: "Check final output", Status: "pending", Priority: "medium"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() {
+		if err := showSubAgentStatus(&runtime.Context{Workspace: workspace, SessionID: "parent-status"}, "child-status"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(output, "Todos:") {
+		t.Fatalf("expected todos section in output: %q", output)
+	}
+	if !strings.Contains(output, "Check final output") {
+		t.Fatalf("expected todo content in output: %q", output)
+	}
+}

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -79,6 +79,7 @@ The native beta supports local tools only:
 - Glob and grep
 - Shell execution
 - Skill reads
+- Todo tracking with `TodoWrite`
 - Sub-agent management
 
 External integrations (`toc runtime invoke`) are not yet part of the native tool loop.
@@ -91,6 +92,27 @@ External integrations (`toc runtime invoke`) are not yet part of the native tool
 4. **State**: persists full message history, token usage, and turn checkpoints to `.toc/sessions/<id>/state.json` for resume
 5. **Events**: writes directly to `.toc/sessions/<id>/events.jsonl` in toc's normalized format
 6. **Skills**: placed in `.toc-native/skills/`
+
+### TodoWrite
+
+The native runtime includes a `TodoWrite` tool for session-scoped task tracking.
+
+- `TodoWrite` replaces the full todo list on each call. It is not incremental.
+- Todos are persisted in `.toc/sessions/<id>/state.json` alongside the rest of the native session state.
+- The current todo list is injected back into model context on each turn, so it stays available even as the conversation grows.
+- `TodoWrite` is intended for the primary agent. Spawned native sub-agents do not receive the tool.
+
+The todo item schema is:
+
+```json
+{
+  "content": "Brief description of the task",
+  "status": "pending | in_progress | completed | cancelled",
+  "priority": "high | medium | low"
+}
+```
+
+For multi-step work, the model is expected to keep the list short, keep at most one item `in_progress` when possible, and rewrite the full list whenever the plan changes.
 
 ### Models
 

--- a/internal/runtime/context_view.go
+++ b/internal/runtime/context_view.go
@@ -11,15 +11,15 @@ import (
 // the old freeform bullet-point summary. It captures actionable state so
 // the model can resume effectively after context is compacted.
 type ContinuationArtifact struct {
-	Goal          string   `json:"goal"`
-	Constraints   []string `json:"constraints,omitempty"`
-	Decisions     []string `json:"decisions,omitempty"`
-	Discoveries   []string `json:"discoveries,omitempty"`
-	WorkingFiles  []string `json:"working_files,omitempty"`
-	CompletedWork []string `json:"completed_work,omitempty"`
-	RemainingWork []string `json:"remaining_work,omitempty"`
-	OpenLoops     []string `json:"open_loops,omitempty"`
-	NextSteps     []string `json:"next_steps,omitempty"`
+	Goal          string    `json:"goal"`
+	Constraints   []string  `json:"constraints,omitempty"`
+	Decisions     []string  `json:"decisions,omitempty"`
+	Discoveries   []string  `json:"discoveries,omitempty"`
+	WorkingFiles  []string  `json:"working_files,omitempty"`
+	CompletedWork []string  `json:"completed_work,omitempty"`
+	RemainingWork []string  `json:"remaining_work,omitempty"`
+	OpenLoops     []string  `json:"open_loops,omitempty"`
+	NextSteps     []string  `json:"next_steps,omitempty"`
 	GeneratedAt   time.Time `json:"generated_at,omitempty"`
 }
 
@@ -103,23 +103,37 @@ func (ws *WorkingSet) Summary() string {
 	return strings.Join(parts, "\n")
 }
 
+func todoSummary(todos []TodoItem) string {
+	if len(todos) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("[toc-todos]\n")
+	b.WriteString("Current session todo list. TodoWrite replaces this list on each call.\n")
+	for _, todo := range todos {
+		b.WriteString(fmt.Sprintf("- %s [%s] %s\n", todo.Status, todo.Priority, todo.Content))
+	}
+	return strings.TrimSpace(b.String())
+}
+
 // ContextDiagnostics captures per-request context usage information for
 // debugging and observability.
 type ContextDiagnostics struct {
-	EstimatedInputTokens int                `json:"estimated_input_tokens"`
-	InputBudget          int                `json:"input_budget"`
-	BudgetDecision       BudgetDecision     `json:"budget_decision"`
+	EstimatedInputTokens int                  `json:"estimated_input_tokens"`
+	InputBudget          int                  `json:"input_budget"`
+	BudgetDecision       BudgetDecision       `json:"budget_decision"`
 	TopContributors      []ContextContributor `json:"top_contributors,omitempty"`
-	MessageCount         int                `json:"message_count"`
-	PrunedCount          int                `json:"pruned_count,omitempty"`
-	CompactionReason     string             `json:"compaction_reason,omitempty"`
-	ContinuationAge      string             `json:"continuation_age,omitempty"`
+	MessageCount         int                  `json:"message_count"`
+	PrunedCount          int                  `json:"pruned_count,omitempty"`
+	CompactionReason     string               `json:"compaction_reason,omitempty"`
+	ContinuationAge      string               `json:"continuation_age,omitempty"`
 }
 
 // ContextContributor identifies a message or category consuming context.
 type ContextContributor struct {
-	Label          string `json:"label"`
-	EstimatedTokens int   `json:"estimated_tokens"`
+	Label           string `json:"label"`
+	EstimatedTokens int    `json:"estimated_tokens"`
 }
 
 // BuildContextDiagnostics computes diagnostics for the current message state.
@@ -191,6 +205,12 @@ func BuildContextView(state *State) []Message {
 		// awareness of which files it has touched without consuming
 		// much budget.
 		if i == 0 && (msg.Role == "system" || isContinuationArtifact(msg) || isCompactionSummary(msg)) {
+			if todos := todoSummary(state.Todos); todos != "" {
+				view = append(view, Message{
+					Role:    "user",
+					Content: todos,
+				})
+			}
 			if wsSummary := state.WorkingSet.Summary(); wsSummary != "" {
 				view = append(view, Message{
 					Role:    "user",

--- a/internal/runtime/context_view_test.go
+++ b/internal/runtime/context_view_test.go
@@ -149,6 +149,48 @@ func TestBuildContextView_InjectsWorkingSet(t *testing.T) {
 	}
 }
 
+func TestTodoSummary(t *testing.T) {
+	summary := todoSummary([]TodoItem{
+		{Content: "Implement todo persistence", Status: "in_progress", Priority: "high"},
+		{Content: "Add tests", Status: "pending", Priority: "medium"},
+	})
+	if !strings.Contains(summary, "[toc-todos]") {
+		t.Fatal("todo summary should include toc-todos header")
+	}
+	if !strings.Contains(summary, "in_progress [high] Implement todo persistence") {
+		t.Fatalf("todo summary missing first todo: %q", summary)
+	}
+	if !strings.Contains(summary, "pending [medium] Add tests") {
+		t.Fatalf("todo summary missing second todo: %q", summary)
+	}
+}
+
+func TestBuildContextView_InjectsTodosBeforeWorkingSet(t *testing.T) {
+	state := &State{
+		Messages: []Message{
+			{Role: "system", Content: "system prompt"},
+			{Role: "user", Content: "hello"},
+		},
+		Todos: []TodoItem{
+			{Content: "Implement TodoWrite", Status: "in_progress", Priority: "high"},
+		},
+		WorkingSet: &WorkingSet{
+			FilesEdited: []string{"main.go"},
+		},
+	}
+
+	view := BuildContextView(state)
+	if len(view) != 4 {
+		t.Fatalf("len(view) = %d, want 4", len(view))
+	}
+	if !strings.Contains(view[1].Content, "[toc-todos]") {
+		t.Fatalf("expected todo injection at view[1], got %q", view[1].Content)
+	}
+	if !strings.Contains(view[2].Content, "[toc-working-set]") {
+		t.Fatalf("expected working set injection at view[2], got %q", view[2].Content)
+	}
+}
+
 func TestBuildContextView_NoWorkingSet(t *testing.T) {
 	state := &State{
 		Messages: []Message{

--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -60,7 +60,7 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 	if state.Prompt == "" && opts.Prompt != "" {
 		state.Prompt = opts.Prompt
 	}
-	if err := ensureSystemPrompt(state); err != nil {
+	if err := ensureSystemPrompt(state, sessionCfg); err != nil {
 		return err
 	}
 	if err := SaveStateInWorkspace(opts.Workspace, opts.SessionID, state); err != nil {
@@ -78,6 +78,7 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 		Workspace:  opts.Workspace,
 		Agent:      opts.Agent,
 		SessionID:  opts.SessionID,
+		State:      state,
 		Manifest:   manifest,
 		Config:     sessionCfg,
 		SpawnFunc:  opts.SpawnFunc,
@@ -345,7 +346,7 @@ func describeTurnCheckpoint(turn *TurnCheckpoint) string {
 	}
 }
 
-func ensureSystemPrompt(state *State) error {
+func ensureSystemPrompt(state *State, sessionCfg *SessionConfig) error {
 	if len(state.Messages) > 0 && state.Messages[0].Role == "system" {
 		// Ensure the system prompt has cache_control set — it's the most
 		// stable content across turns and benefits most from caching.
@@ -370,6 +371,13 @@ func ensureSystemPrompt(state *State) error {
 			content = catalog
 		}
 	}
+	if runtimeNotes := buildNativeRuntimeNotes(sessionCfg); runtimeNotes != "" {
+		if content != "" {
+			content = content + "\n\n" + runtimeNotes
+		} else {
+			content = runtimeNotes
+		}
+	}
 
 	if content == "" {
 		return nil
@@ -380,6 +388,27 @@ func ensureSystemPrompt(state *State) error {
 		CacheControl: &cacheControl{Type: "ephemeral"},
 	}}, state.Messages...)
 	return nil
+}
+
+func buildNativeRuntimeNotes(sessionCfg *SessionConfig) string {
+	if sessionCfg == nil {
+		return ""
+	}
+	if !toolEnabled(sessionCfg.RuntimeConfig.EnabledTools, "TodoWrite") {
+		return ""
+	}
+	return `If the task has multiple meaningful steps, use the TodoWrite tool to keep a short session todo list current.
+TodoWrite replaces the entire list on each call, so always send the full updated list.
+Prefer only one item with status "in_progress" at a time and mark items complete immediately.`
+}
+
+func toolEnabled(enabled []string, name string) bool {
+	for _, tool := range enabled {
+		if tool == name {
+			return true
+		}
+	}
+	return false
 }
 
 // buildSkillCatalog scans skillsDir for provisioned skills and returns an XML

--- a/internal/runtime/native_test.go
+++ b/internal/runtime/native_test.go
@@ -204,7 +204,7 @@ func TestEnsureSystemPromptInjectsSkillCatalog(t *testing.T) {
 
 	// No skills yet — system prompt alone.
 	state := &State{SessionDir: sessionDir}
-	if err := ensureSystemPrompt(state); err != nil {
+	if err := ensureSystemPrompt(state, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(state.Messages) != 1 || state.Messages[0].Role != "system" {
@@ -224,7 +224,7 @@ func TestEnsureSystemPromptInjectsSkillCatalog(t *testing.T) {
 	}
 
 	state2 := &State{SessionDir: sessionDir}
-	if err := ensureSystemPrompt(state2); err != nil {
+	if err := ensureSystemPrompt(state2, nil); err != nil {
 		t.Fatal(err)
 	}
 	content := state2.Messages[0].Content
@@ -248,11 +248,37 @@ func TestEnsureSystemPromptInjectsSkillCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 	state3 := &State{SessionDir: sessionDir3}
-	if err := ensureSystemPrompt(state3); err != nil {
+	if err := ensureSystemPrompt(state3, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(state3.Messages) != 1 || !strings.Contains(state3.Messages[0].Content, "available_skills") {
 		t.Errorf("expected skill-only system prompt, got %+v", state3.Messages)
+	}
+}
+
+func TestEnsureSystemPromptInjectsTodoWriteNotes(t *testing.T) {
+	sessionDir := t.TempDir()
+	nativeDir := filepath.Join(sessionDir, ".toc-native")
+
+	if err := os.MkdirAll(nativeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nativeDir, "system-prompt.md"), []byte("You are an agent.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	state := &State{SessionDir: sessionDir}
+	cfg := &SessionConfig{
+		RuntimeConfig: SessionRuntimeOptions{
+			EnabledTools: []string{"Read", "TodoWrite"},
+		},
+	}
+	if err := ensureSystemPrompt(state, cfg); err != nil {
+		t.Fatal(err)
+	}
+	content := state.Messages[0].Content
+	if !strings.Contains(content, "TodoWrite tool") {
+		t.Fatalf("expected TodoWrite runtime notes in system prompt, got %q", content)
 	}
 }
 

--- a/internal/runtime/native_tool_registry.go
+++ b/internal/runtime/native_tool_registry.go
@@ -211,6 +211,45 @@ Anti-patterns:
 			Handler: nativeSkill,
 		},
 		{
+			Name: "TodoWrite",
+			Description: `Replace the current session todo list with a new ordered list.
+
+Use TodoWrite for multi-step work, especially when you need to track progress across file edits, tests, and sub-agent coordination. Each call replaces the entire list, so always send the full current todo list.
+
+Parameters:
+- todos (required): Complete ordered todo list. Each item must include:
+  - content: brief task description
+  - status: pending, in_progress, completed, or cancelled
+  - priority: high, medium, or low
+
+Guidelines:
+- Prefer using TodoWrite when the task has multiple meaningful steps.
+- Keep only one item in_progress at a time when possible.
+- Mark items completed immediately after finishing them.
+- If the plan changes, rewrite the full list to match the new reality.
+
+Output: A short summary confirming the updated todo list.`,
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"todos": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"content":  map[string]interface{}{"type": "string", "description": "Brief description of the task"},
+								"status":   map[string]interface{}{"type": "string", "enum": []string{"pending", "in_progress", "completed", "cancelled"}},
+								"priority": map[string]interface{}{"type": "string", "enum": []string{"high", "medium", "low"}},
+							},
+							"required": []string{"content", "status", "priority"},
+						},
+					},
+				},
+				"required": []string{"todos"},
+			},
+			Handler: nativeTodoWrite,
+		},
+		{
 			Name: "SubAgent",
 			Description: `Manage sub-agent sessions for multi-agent orchestration. Sub-agents run in the background as separate sessions with their own workspace, allowing parallel task execution.
 

--- a/internal/runtime/native_tool_registry_test.go
+++ b/internal/runtime/native_tool_registry_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNativeToolNames(t *testing.T) {
 	got := NativeToolNames()
-	want := []string{"Read", "Write", "Edit", "Glob", "Grep", "Bash", "Skill", "SubAgent"}
+	want := []string{"Read", "Write", "Edit", "Glob", "Grep", "Bash", "Skill", "TodoWrite", "SubAgent"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("NativeToolNames() = %#v, want %#v", got, want)
 	}

--- a/internal/runtime/native_tools.go
+++ b/internal/runtime/native_tools.go
@@ -25,6 +25,7 @@ type nativeToolContext struct {
 	Workspace  string
 	Agent      string
 	SessionID  string
+	State      *State
 	Manifest   *integration.PermissionManifest
 	Config     *SessionConfig
 	SpawnFunc  SubAgentSpawnFunc
@@ -368,6 +369,104 @@ func nativeSkill(ctx nativeToolContext, call ToolCall) toolExecution {
 		Skill:   name,
 		Success: boolPtr(true),
 	})
+}
+
+func nativeTodoWrite(ctx nativeToolContext, call ToolCall) toolExecution {
+	if ctx.State == nil {
+		return toolFailure("TodoWrite", "", "", fmt.Errorf("todo state is not available"))
+	}
+
+	var args struct {
+		Todos []TodoItem `json:"todos"`
+	}
+	if err := decodeToolArgs(call.Function.Arguments, &args); err != nil {
+		return toolFailure("TodoWrite", "", "", err)
+	}
+
+	normalized := make([]TodoItem, 0, len(args.Todos))
+	for i, todo := range args.Todos {
+		content := strings.TrimSpace(todo.Content)
+		if content == "" {
+			return toolFailure("TodoWrite", "", "", fmt.Errorf("todo %d content must not be empty", i+1))
+		}
+		status := strings.TrimSpace(todo.Status)
+		if !isValidTodoStatus(status) {
+			return toolFailure("TodoWrite", "", "", fmt.Errorf("todo %d has invalid status %q", i+1, todo.Status))
+		}
+		priority := strings.TrimSpace(todo.Priority)
+		if !isValidTodoPriority(priority) {
+			return toolFailure("TodoWrite", "", "", fmt.Errorf("todo %d has invalid priority %q", i+1, todo.Priority))
+		}
+		normalized = append(normalized, TodoItem{
+			Content:  content,
+			Status:   status,
+			Priority: priority,
+		})
+	}
+
+	if len(normalized) == 0 {
+		ctx.State.Todos = nil
+	} else {
+		ctx.State.Todos = normalized
+	}
+
+	message := summarizeTodos(normalized)
+	return toolSuccess("TodoWrite", "", message, Step{
+		Type:    "tool",
+		Tool:    "TodoWrite",
+		Content: message,
+		Success: boolPtr(true),
+	})
+}
+
+func isValidTodoStatus(status string) bool {
+	switch status {
+	case "pending", "in_progress", "completed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidTodoPriority(priority string) bool {
+	switch priority {
+	case "high", "medium", "low":
+		return true
+	default:
+		return false
+	}
+}
+
+func summarizeTodos(todos []TodoItem) string {
+	if len(todos) == 0 {
+		return "Cleared todo list."
+	}
+
+	counts := map[string]int{
+		"pending":     0,
+		"in_progress": 0,
+		"completed":   0,
+		"cancelled":   0,
+	}
+	for _, todo := range todos {
+		counts[todo.Status]++
+	}
+
+	parts := []string{}
+	if counts["in_progress"] > 0 {
+		parts = append(parts, fmt.Sprintf("%d in progress", counts["in_progress"]))
+	}
+	if counts["pending"] > 0 {
+		parts = append(parts, fmt.Sprintf("%d pending", counts["pending"]))
+	}
+	if counts["completed"] > 0 {
+		parts = append(parts, fmt.Sprintf("%d completed", counts["completed"]))
+	}
+	if counts["cancelled"] > 0 {
+		parts = append(parts, fmt.Sprintf("%d cancelled", counts["cancelled"]))
+	}
+
+	return fmt.Sprintf("Updated %d todos: %s.", len(todos), strings.Join(parts, ", "))
 }
 
 func toolSuccess(toolName, path, message string, step Step) toolExecution {

--- a/internal/runtime/native_tools_test.go
+++ b/internal/runtime/native_tools_test.go
@@ -193,6 +193,60 @@ func TestNativeBashRejectsEmptyCommand(t *testing.T) {
 	}
 }
 
+func TestNativeTodoWriteUpdatesState(t *testing.T) {
+	dir := t.TempDir()
+	state := &State{}
+
+	result := nativeTodoWrite(nativeToolContext{
+		SessionDir: dir,
+		Agent:      "tester",
+		State:      state,
+	}, toolCall(t, "TodoWrite", map[string]interface{}{
+		"todos": []map[string]interface{}{
+			{"content": "Implement TodoWrite", "status": "in_progress", "priority": "high"},
+			{"content": "Add tests", "status": "pending", "priority": "medium"},
+		},
+	}))
+
+	if result.Step.Success == nil || !*result.Step.Success {
+		t.Fatalf("expected TodoWrite success, got %#v", result)
+	}
+	if len(state.Todos) != 2 {
+		t.Fatalf("len(state.Todos) = %d, want 2", len(state.Todos))
+	}
+	if state.Todos[0].Content != "Implement TodoWrite" || state.Todos[1].Status != "pending" {
+		t.Fatalf("unexpected todos in state: %#v", state.Todos)
+	}
+	if !strings.Contains(result.Message, "Updated 2 todos") {
+		t.Fatalf("unexpected summary message: %q", result.Message)
+	}
+}
+
+func TestNativeTodoWriteRejectsInvalidStatus(t *testing.T) {
+	dir := t.TempDir()
+	state := &State{}
+
+	result := nativeTodoWrite(nativeToolContext{
+		SessionDir: dir,
+		Agent:      "tester",
+		State:      state,
+	}, toolCall(t, "TodoWrite", map[string]interface{}{
+		"todos": []map[string]interface{}{
+			{"content": "Bad todo", "status": "doing", "priority": "high"},
+		},
+	}))
+
+	if result.Step.Success == nil || *result.Step.Success {
+		t.Fatalf("expected TodoWrite failure, got %#v", result)
+	}
+	if !strings.Contains(result.Message, `invalid status "doing"`) {
+		t.Fatalf("unexpected error message: %q", result.Message)
+	}
+	if len(state.Todos) != 0 {
+		t.Fatalf("state should be unchanged on failure, got %#v", state.Todos)
+	}
+}
+
 func toolCall(t *testing.T, name string, args map[string]interface{}) ToolCall {
 	t.Helper()
 	data, err := json.Marshal(args)

--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -32,6 +32,12 @@ type ToolCallFunction struct {
 	Arguments string `json:"arguments,omitempty"`
 }
 
+type TodoItem struct {
+	Content  string `json:"content"`
+	Status   string `json:"status"`
+	Priority string `json:"priority"`
+}
+
 func (m *Message) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Role       string          `json:"role"`
@@ -59,18 +65,18 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 
 // State is the persisted runtime session state used for resume.
 type State struct {
-	Version           int                `json:"version"`
-	Runtime           string             `json:"runtime"`
-	SessionID         string             `json:"session_id"`
-	Agent             string             `json:"agent"`
-	Model             string             `json:"model,omitempty"`
-	Workspace         string             `json:"workspace,omitempty"`
-	SessionDir        string             `json:"session_dir,omitempty"`
-	Mode              string             `json:"mode,omitempty"`
-	Status            string             `json:"status,omitempty"`
-	Prompt            string             `json:"prompt,omitempty"`
-	ResumeCount       int                `json:"resume_count,omitempty"`
-	RecoveryCount     int                `json:"recovery_count,omitempty"`
+	Version           int                   `json:"version"`
+	Runtime           string                `json:"runtime"`
+	SessionID         string                `json:"session_id"`
+	Agent             string                `json:"agent"`
+	Model             string                `json:"model,omitempty"`
+	Workspace         string                `json:"workspace,omitempty"`
+	SessionDir        string                `json:"session_dir,omitempty"`
+	Mode              string                `json:"mode,omitempty"`
+	Status            string                `json:"status,omitempty"`
+	Prompt            string                `json:"prompt,omitempty"`
+	ResumeCount       int                   `json:"resume_count,omitempty"`
+	RecoveryCount     int                   `json:"recovery_count,omitempty"`
 	CompactionCount   int                   `json:"compaction_count,omitempty"`
 	CompactedMessages int                   `json:"compacted_messages,omitempty"`
 	LastError         string                `json:"last_error,omitempty"`
@@ -81,12 +87,13 @@ type State struct {
 	LastRequestUsage  LastRequestUsage      `json:"last_request_usage,omitempty"`
 	Messages          []Message             `json:"messages,omitempty"`
 	Transcript        []Message             `json:"transcript,omitempty"`
+	Todos             []TodoItem            `json:"todos,omitempty"`
 	Continuation      *ContinuationArtifact `json:"continuation,omitempty"`
 	WorkingSet        *WorkingSet           `json:"working_set,omitempty"`
 	PendingTurn       *TurnCheckpoint       `json:"pending_turn,omitempty"`
 	CrashInfo         *CrashInfo            `json:"crash_info,omitempty"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
+	CreatedAt         time.Time             `json:"created_at"`
+	UpdatedAt         time.Time             `json:"updated_at"`
 }
 
 type CrashInfo struct {

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tiny-oc/toc/internal/naming"
 	"github.com/tiny-oc/toc/internal/registry"
 	"github.com/tiny-oc/toc/internal/runtime"
+	"github.com/tiny-oc/toc/internal/runtimeinfo"
 	"github.com/tiny-oc/toc/internal/session"
 	"github.com/tiny-oc/toc/internal/skill"
 	"github.com/tiny-oc/toc/internal/ui"
@@ -234,6 +235,7 @@ func SpawnSubSession(cfg *agent.AgentConfig, opts SubSpawnOpts) (*SpawnResult, e
 	sessionCfg := runtime.ResolveSessionConfig(cfg, runtime.ResolveOptions{
 		MaxIterationsOverride: opts.MaxIterations,
 	})
+	restrictNativeSubAgentTools(sessionCfg)
 	if err := runtime.ValidateSessionConfig(sessionCfg); err != nil {
 		return nil, err
 	}
@@ -342,6 +344,7 @@ func ResumeSubSession(s *session.Session, opts SubResumeOpts) (*SpawnResult, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to load session config: %w", err)
 	}
+	restrictNativeSubAgentTools(sessionCfg)
 	if err := runtime.ValidateSessionConfig(sessionCfg); err != nil {
 		return nil, fmt.Errorf("invalid session config: %w", err)
 	}
@@ -399,6 +402,28 @@ func runPostSessionSync(provider runtime.Provider, workDir, agentDir string, pat
 		}
 	}
 	return len(synced)
+}
+
+func restrictNativeSubAgentTools(cfg *runtime.SessionConfig) {
+	if cfg == nil || cfg.Runtime != runtimeinfo.NativeRuntime {
+		return
+	}
+	if len(cfg.RuntimeConfig.EnabledTools) == 0 {
+		return
+	}
+
+	disabled := map[string]bool{
+		"TodoWrite": true,
+		"SubAgent":  true,
+	}
+	filtered := make([]string, 0, len(cfg.RuntimeConfig.EnabledTools))
+	for _, tool := range cfg.RuntimeConfig.EnabledTools {
+		if disabled[tool] {
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	cfg.RuntimeConfig.EnabledTools = filtered
 }
 
 func printResumeCommand(agentName, sessionID string) {

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -254,6 +254,22 @@ func TestBuildDetachedScript_AtomicRename(t *testing.T) {
 	}
 }
 
+func TestRestrictNativeSubAgentTools(t *testing.T) {
+	cfg := &runtime.SessionConfig{
+		Runtime: runtimeinfo.NativeRuntime,
+		RuntimeConfig: runtime.SessionRuntimeOptions{
+			EnabledTools: []string{"Read", "TodoWrite", "Bash", "SubAgent"},
+		},
+	}
+
+	restrictNativeSubAgentTools(cfg)
+
+	got := strings.Join(cfg.RuntimeConfig.EnabledTools, ",")
+	if got != "Read,Bash" {
+		t.Fatalf("EnabledTools = %q, want %q", got, "Read,Bash")
+	}
+}
+
 func TestLoadOrResolveSessionConfig_PrefersPersistedConfig(t *testing.T) {
 	workspace := t.TempDir()
 	sessionID := "sess-persisted"


### PR DESCRIPTION
This adds a native TodoWrite tool backed by session state instead of a separate store. Todos are persisted in native runtime state, injected back into context each turn, and surfaced in runtime status/output for visibility. Spawned native subagents now have TodoWrite and nested SubAgent orchestration disabled to keep planning with the primary agent. It also documents the new behavior and adds coverage across cmd, runtime, and spawn tests, including a passing ok  	github.com/tiny-oc/toc/cmd	(cached)
ok  	github.com/tiny-oc/toc/internal/runtime	(cached)
ok  	github.com/tiny-oc/toc/internal/spawn	(cached).