### PR TITLE
Support small_model in toc-native compaction

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ runtime: claude-code
 name: pr-reviewer
 description: Reviews pull requests for code quality
 model: sonnet
+small_model: haiku
 context:
   - context/*.md
   - docs/
@@ -46,6 +47,7 @@ permissions:
 | `name` | string | yes | — | Lowercase alphanumeric with hyphens (e.g. `pr-reviewer`). Must match `^[a-z0-9][a-z0-9-]*$` |
 | `description` | string | no | — | Shown in `toc agent list` and shell tab completion |
 | `model` | string | yes | — | Declarative model preference for the selected runtime. For `claude-code`: `sonnet`, `opus`, or `haiku`. For `toc-native`, use an OpenRouter model ID such as `openai/gpt-4o-mini` |
+| `small_model` | string | no | — | Optional secondary model preference for lightweight work. In `toc-native`, structured compaction uses this model when set, otherwise it falls back to `model` |
 | `allow_custom_native_model` | bool | no | `false` | For `toc-native`, allow a model outside the supported beta profile set. Use only as an explicit override for experimental models |
 | `context` | list | no | — | Glob patterns for snapshot sync between the parent snapshot and spawned sessions (see below) |
 | `skills` | list | no | — | Skill names (local) or Git URLs (remote) |
@@ -86,6 +88,7 @@ If you want to experiment with a model outside that supported set, you must opt 
 ```yaml
 runtime: toc-native
 model: some/provider-model
+small_model: some/provider-small-model
 allow_custom_native_model: true
 ```
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -107,10 +107,13 @@ To use a model outside this set, opt in explicitly:
 ```yaml
 runtime: toc-native
 model: some/other-model
+small_model: some/other-small-model
 allow_custom_native_model: true
 ```
 
 Custom models must support tool calling to work with the native runtime.
+
+`toc-native` also supports an optional `small_model` field. When set, the runtime uses that model for lightweight compaction summarization work and falls back to `model` for the main tool loop.
 
 ### Configuration
 
@@ -134,6 +137,8 @@ The native runtime actively manages context to maintain model quality over long 
 4. **Fail-safe**: If context remains over budget after emergency compaction, the runtime returns an error rather than sending an over-budget request.
 
 The continuation artifact replaces the old freeform summary with structured fields that help the model resume effectively after compaction.
+
+If `small_model` is configured, the continuation artifact is synthesized with that model instead of the primary `model`, which reduces cost and latency for compaction turns.
 
 **Working set tracking**: The runtime tracks files read, edited, and written, along with recent shell commands. This metadata feeds into compaction and diagnostics.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -42,6 +42,7 @@ type AgentConfig struct {
 	Name                   string       `yaml:"name"`
 	Description            string       `yaml:"description,omitempty"`
 	Model                  string       `yaml:"model"`
+	SmallModel             string       `yaml:"small_model,omitempty"`
 	AllowCustomNativeModel bool         `yaml:"allow_custom_native_model,omitempty"`
 	MaxIterations          int          `yaml:"max_iterations,omitempty"`
 	Context                []string     `yaml:"context,omitempty"`
@@ -148,6 +149,10 @@ func (cfg *AgentConfig) Validate() []string {
 			problems = append(problems, "missing model")
 		} else if err := runtimeinfo.ValidateModelSelection(cfg.Runtime, cfg.Model, cfg.AllowCustomNativeModel); err != nil {
 			problems = append(problems, err.Error())
+		} else if strings.TrimSpace(cfg.SmallModel) != "" {
+			if err := runtimeinfo.ValidateModelSelection(cfg.Runtime, cfg.SmallModel, cfg.AllowCustomNativeModel); err != nil {
+				problems = append(problems, fmt.Sprintf("invalid small_model: %v", err))
+			}
 		}
 	}
 	if cfg.Runtime == "" && cfg.Model == "" {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEffectivePermissions_Defaults(t *testing.T) {
 	cfg := &AgentConfig{Name: "test", Runtime: "claude-code", Model: "sonnet"}
@@ -166,6 +169,36 @@ func TestValidate_NativeCustomModelAllowedWithOverride(t *testing.T) {
 	problems := cfg.Validate()
 	if len(problems) != 0 {
 		t.Fatalf("expected override to allow custom native model, got %v", problems)
+	}
+}
+
+func TestValidate_SmallModelRequiresNativeOverride(t *testing.T) {
+	cfg := &AgentConfig{
+		Name:       "test",
+		Runtime:    "toc-native",
+		Model:      "openai/gpt-4o-mini",
+		SmallModel: "meta-llama/unknown",
+	}
+	problems := cfg.Validate()
+	if len(problems) == 0 {
+		t.Fatal("expected validation error for unsupported custom small_model")
+	}
+	if got := problems[0]; !strings.Contains(got, "invalid small_model:") {
+		t.Fatalf("expected small_model validation error, got %v", problems)
+	}
+}
+
+func TestValidate_SmallModelAllowedWithNativeOverride(t *testing.T) {
+	cfg := &AgentConfig{
+		Name:                   "test",
+		Runtime:                "toc-native",
+		Model:                  "openai/gpt-4o-mini",
+		SmallModel:             "meta-llama/unknown",
+		AllowCustomNativeModel: true,
+	}
+	problems := cfg.Validate()
+	if len(problems) != 0 {
+		t.Fatalf("expected override to allow custom small_model, got %v", problems)
 	}
 }
 

--- a/internal/runtime/native_compaction.go
+++ b/internal/runtime/native_compaction.go
@@ -46,14 +46,14 @@ func maybeManageContext(state *State, sess *session.Session, cfg *SessionConfig,
 		}
 	}
 
-	return manageContextWithBudget(state, sess, keepRecent, maxSummaryChars, profile, client)
+	return manageContextWithBudget(state, sess, cfg, keepRecent, maxSummaryChars, profile, client)
 }
 
 // manageContextWithBudget implements the token-budget-aware context pipeline:
-//   1. Estimate current input tokens
-//   2. Consult the budgeter for a decision
-//   3. Prune → compact → fail based on the decision
-func manageContextWithBudget(state *State, sess *session.Session, keepRecent, maxSummaryChars int, profile runtimeinfo.NativeModelProfile, client *openRouterClient) (bool, error) {
+//  1. Estimate current input tokens
+//  2. Consult the budgeter for a decision
+//  3. Prune → compact → fail based on the decision
+func manageContextWithBudget(state *State, sess *session.Session, cfg *SessionConfig, keepRecent, maxSummaryChars int, profile runtimeinfo.NativeModelProfile, client *openRouterClient) (bool, error) {
 	budgeter := NewContextBudgeter(profile)
 	currentTokens := estimateMessagesTokens(state.Messages)
 	decision := budgeter.Evaluate(currentTokens)
@@ -84,7 +84,7 @@ func manageContextWithBudget(state *State, sess *session.Session, keepRecent, ma
 		}
 
 		// Full compaction needed
-		compacted, compactedCount, _ := compactMessagesStructured(state, keepRecent, maxSummaryChars, client)
+		compacted, compactedCount, _ := compactMessagesStructuredWithModel(state, cfg, keepRecent, maxSummaryChars, client)
 		if compactedCount == 0 {
 			return pruned > 0, nil
 		}
@@ -100,7 +100,7 @@ func manageContextWithBudget(state *State, sess *session.Session, keepRecent, ma
 	case BudgetFail:
 		// Emergency: try aggressive pruning + compaction before giving up
 		pruneStaleToolOutputs(state.Messages, keepRecent)
-		compacted, compactedCount, _ := compactMessagesStructured(state, keepRecent, maxSummaryChars, client)
+		compacted, compactedCount, _ := compactMessagesStructuredWithModel(state, cfg, keepRecent, maxSummaryChars, client)
 		if compactedCount > 0 {
 			state.Messages = compacted
 			state.CompactionCount++
@@ -188,6 +188,10 @@ func looksLikeError(content string) bool {
 // continuation artifact. When a client is available, uses the LLM to generate
 // the continuation; falls back to heuristic extraction otherwise.
 func compactMessagesStructured(state *State, keepRecent, maxSummaryChars int, client *openRouterClient) ([]Message, int, string) {
+	return compactMessagesStructuredWithModel(state, nil, keepRecent, maxSummaryChars, client)
+}
+
+func compactMessagesStructuredWithModel(state *State, cfg *SessionConfig, keepRecent, maxSummaryChars int, client *openRouterClient) ([]Message, int, string) {
 	messages := state.Messages
 	if len(messages) == 0 {
 		return messages, 0, ""
@@ -216,8 +220,9 @@ func compactMessagesStructured(state *State, keepRecent, maxSummaryChars int, cl
 
 	// Try LLM-generated continuation first; fall back to heuristic extraction.
 	var continuation ContinuationArtifact
-	if client != nil && state.Model != "" {
-		llmCont, err := generateContinuationViaLLM(client, state.Model, head, state.Continuation)
+	compactionModel := resolveCompactionModel(state, cfg)
+	if client != nil && compactionModel != "" {
+		llmCont, err := generateContinuationViaLLM(client, compactionModel, head, state.Continuation)
 		if err == nil && llmCont != nil {
 			continuation = *llmCont
 		} else {
@@ -242,6 +247,21 @@ func compactMessagesStructured(state *State, keepRecent, maxSummaryChars int, cl
 	})
 	compacted = append(compacted, tail...)
 	return compacted, compactedCount, continuationText
+}
+
+func resolveCompactionModel(state *State, cfg *SessionConfig) string {
+	if cfg != nil {
+		if smallModel := strings.TrimSpace(cfg.SmallModel); smallModel != "" {
+			return smallModel
+		}
+		if model := strings.TrimSpace(cfg.Model); model != "" {
+			return model
+		}
+	}
+	if state == nil {
+		return ""
+	}
+	return strings.TrimSpace(state.Model)
 }
 
 // buildContinuationFromMessages extracts structured context from compacted

--- a/internal/runtime/native_compaction_test.go
+++ b/internal/runtime/native_compaction_test.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -38,6 +41,103 @@ func TestCompactMessagesStructured_PreservesSystemAndRecentTail(t *testing.T) {
 	}
 	if compacted[2].Content != "second request" || compacted[3].Content != "second answer" {
 		t.Fatalf("unexpected preserved tail: %#v", compacted[2:])
+	}
+}
+
+func TestResolveCompactionModel(t *testing.T) {
+	state := &State{Model: "openai/gpt-4o"}
+
+	if got := resolveCompactionModel(state, nil); got != "openai/gpt-4o" {
+		t.Fatalf("resolveCompactionModel(nil cfg) = %q", got)
+	}
+	if got := resolveCompactionModel(state, &SessionConfig{Model: "openai/gpt-4o-mini"}); got != "openai/gpt-4o-mini" {
+		t.Fatalf("resolveCompactionModel(primary fallback) = %q", got)
+	}
+	if got := resolveCompactionModel(state, &SessionConfig{
+		Model:      "openai/gpt-4o-mini",
+		SmallModel: "anthropic/claude-sonnet-4",
+	}); got != "anthropic/claude-sonnet-4" {
+		t.Fatalf("resolveCompactionModel(small model) = %q", got)
+	}
+}
+
+func TestMaybeManageContext_UsesSmallModelForCompaction(t *testing.T) {
+	sess := &session.Session{
+		ID:          "sess-small-model",
+		Runtime:     runtimeinfo.NativeRuntime,
+		MetadataDir: t.TempDir(),
+	}
+
+	state := &State{
+		Runtime:   runtimeinfo.NativeRuntime,
+		SessionID: sess.ID,
+		Model:     "openai/gpt-4o",
+		Messages: []Message{
+			{Role: "system", Content: "system prompt"},
+			{Role: "user", Content: strings.Repeat("a", 2500)},
+			{Role: "assistant", Content: strings.Repeat("b", 2500)},
+			{Role: "tool", Name: "Read", Content: strings.Repeat("c", 2500)},
+			{Role: "user", Content: "keep"},
+			{Role: "assistant", Content: "recent"},
+		},
+	}
+	cfg := &SessionConfig{
+		Model:      "openai/gpt-4o",
+		SmallModel: "openai/gpt-4o-mini",
+		RuntimeConfig: SessionRuntimeOptions{
+			CompactionKeepRecent: 2,
+		},
+	}
+	profile := runtimeinfo.NativeModelProfile{
+		ContextWindow:   1800,
+		MaxOutputTokens: 512,
+		ReservedBuffer:  256,
+	}
+
+	var gotModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotModel = req.Model
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":    "resp-compaction",
+			"model": req.Model,
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"role":    "assistant",
+						"content": `{"goal":"keep context","completed_work":["summarized earlier work"],"next_steps":["continue from recent messages"]}`,
+					},
+					"finish_reason": "stop",
+				},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &openRouterClient{
+		baseURL:    server.URL,
+		apiKey:     "test-key",
+		httpClient: server.Client(),
+	}
+
+	changed, err := maybeManageContext(state, sess, cfg, profile, client)
+	if err != nil {
+		t.Fatalf("maybeManageContext() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected context compaction to change state")
+	}
+	if gotModel != cfg.SmallModel {
+		t.Fatalf("compaction model = %q, want %q", gotModel, cfg.SmallModel)
+	}
+	if len(state.Messages) < 2 || !isContinuationArtifact(state.Messages[1]) {
+		t.Fatalf("expected continuation artifact after compaction, got %#v", state.Messages)
 	}
 }
 
@@ -92,7 +192,7 @@ func TestBudgetFail_EmergencyCompaction(t *testing.T) {
 		},
 	}
 
-	changed, err := manageContextWithBudget(state, sess, 2, 6000, profile, nil)
+	changed, err := manageContextWithBudget(state, sess, nil, 2, 6000, profile, nil)
 
 	// Emergency compaction should have fired. If it managed to compact below
 	// the fail threshold, changed=true and no error. If still over, we get an error.
@@ -209,9 +309,9 @@ func TestAgeToolResults_PreservesRecentMessages(t *testing.T) {
 	largeContent := strings.Repeat("x", 100*1024)
 	messages := []Message{
 		{Role: "system", Content: "system prompt"},
-		{Role: "tool", Name: "Read", Content: largeContent},  // old — should be aged
+		{Role: "tool", Name: "Read", Content: largeContent}, // old — should be aged
 		{Role: "user", Content: "middle"},
-		{Role: "tool", Name: "Read", Content: largeContent},  // recent — should be preserved
+		{Role: "tool", Name: "Read", Content: largeContent}, // recent — should be preserved
 		{Role: "assistant", Content: "reply"},
 	}
 
@@ -269,7 +369,7 @@ func TestContextBudgeter_Evaluate(t *testing.T) {
 		want   BudgetDecision
 	}{
 		{"low usage", budget / 2, BudgetContinue},
-		{"below prune", budget * 3 / 4 - 1, BudgetContinue},
+		{"below prune", budget*3/4 - 1, BudgetContinue},
 		{"at prune threshold", budget * 3 / 4, BudgetPrune},
 		{"between prune and compact", budget * 4 / 5, BudgetPrune},
 		{"at compact threshold", budget * 9 / 10, BudgetCompact},
@@ -489,7 +589,7 @@ func TestManageContextWithBudget_PrunesBeforeCompaction(t *testing.T) {
 		ReservedBuffer:  4096,
 	}
 
-	changed, err := manageContextWithBudget(state, sess, 2, 6000, profile, nil)
+	changed, err := manageContextWithBudget(state, sess, nil, 2, 6000, profile, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +636,7 @@ func TestManageContextWithBudget_CompactsWhenNeeded(t *testing.T) {
 		},
 	}
 
-	changed, err := manageContextWithBudget(state, sess, 2, 6000, profile, nil)
+	changed, err := manageContextWithBudget(state, sess, nil, 2, 6000, profile, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -754,4 +854,3 @@ func TestTranscriptSurvivesCompaction(t *testing.T) {
 		t.Error("Transcript should still have original messages")
 	}
 }
-

--- a/internal/runtime/session_config.go
+++ b/internal/runtime/session_config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/tiny-oc/toc/internal/agent"
 	"github.com/tiny-oc/toc/internal/integration"
@@ -34,6 +35,7 @@ type SessionConfig struct {
 	Agent                  string                `json:"agent"`
 	Runtime                string                `json:"runtime"`
 	Model                  string                `json:"model"`
+	SmallModel             string                `json:"small_model,omitempty"`
 	AllowCustomNativeModel bool                  `json:"allow_custom_native_model,omitempty"`
 	Description            string                `json:"description,omitempty"`
 	Context                []string              `json:"context,omitempty"`
@@ -65,6 +67,7 @@ func ResolveSessionConfig(cfg *agent.AgentConfig, opts ...ResolveOptions) *Sessi
 		Agent:                  cfg.Name,
 		Runtime:                cfg.Runtime,
 		Model:                  cfg.Model,
+		SmallModel:             cfg.SmallModel,
 		AllowCustomNativeModel: cfg.AllowCustomNativeModel,
 		Description:            cfg.Description,
 		Context:                append([]string(nil), cfg.Context...),
@@ -103,6 +106,11 @@ func ValidateSessionConfig(cfg *SessionConfig) error {
 	}
 	if err := runtimeinfo.ValidateModelSelection(cfg.Runtime, cfg.Model, cfg.AllowCustomNativeModel); err != nil {
 		return err
+	}
+	if strings.TrimSpace(cfg.SmallModel) != "" {
+		if err := runtimeinfo.ValidateModelSelection(cfg.Runtime, cfg.SmallModel, cfg.AllowCustomNativeModel); err != nil {
+			return fmt.Errorf("invalid small_model: %w", err)
+		}
 	}
 	for name, grants := range cfg.Permissions.Integrations {
 		def, err := integration.LoadFromRegistry(name)

--- a/internal/runtime/session_config_test.go
+++ b/internal/runtime/session_config_test.go
@@ -14,6 +14,7 @@ func TestResolveSessionConfig(t *testing.T) {
 		Name:                   "native-agent",
 		Runtime:                runtimeinfo.NativeRuntime,
 		Model:                  "openai/gpt-4o-mini",
+		SmallModel:             "openai/gpt-4o-mini",
 		AllowCustomNativeModel: true,
 		Context:                []string{"context/*.md"},
 		Skills:                 []string{"code-review"},
@@ -42,6 +43,9 @@ func TestResolveSessionConfig(t *testing.T) {
 	}
 	if !cfg.AllowCustomNativeModel {
 		t.Fatalf("expected AllowCustomNativeModel to propagate, got %#v", cfg)
+	}
+	if cfg.SmallModel != "openai/gpt-4o-mini" {
+		t.Fatalf("expected SmallModel to propagate, got %#v", cfg)
 	}
 	if cfg.RuntimeConfig.CompactionTriggerChars != 0 {
 		t.Fatalf("CompactionTriggerChars should no longer be set by default (token budgets are primary), got %d", cfg.RuntimeConfig.CompactionTriggerChars)
@@ -73,13 +77,16 @@ func TestSaveAndLoadSessionConfig(t *testing.T) {
 	if loaded.Model != cfg.Model || loaded.LLM.Provider != "openrouter" {
 		t.Fatalf("loaded session config = %#v", loaded)
 	}
+	if loaded.SmallModel != cfg.SmallModel {
+		t.Fatalf("loaded SmallModel = %q, want %q", loaded.SmallModel, cfg.SmallModel)
+	}
 }
 
 func TestResolveSessionConfig_MaxIterations_Default(t *testing.T) {
 	cfg := ResolveSessionConfig(&agent.AgentConfig{
-		Name:    "test-agent",
-		Runtime: runtimeinfo.NativeRuntime,
-		Model:   "openai/gpt-4o-mini",
+		Name:                   "test-agent",
+		Runtime:                runtimeinfo.NativeRuntime,
+		Model:                  "openai/gpt-4o-mini",
 		AllowCustomNativeModel: true,
 	})
 	if cfg.RuntimeConfig.MaxIterations != defaultMaxIterations {
@@ -89,10 +96,10 @@ func TestResolveSessionConfig_MaxIterations_Default(t *testing.T) {
 
 func TestResolveSessionConfig_MaxIterations_AgentYAML(t *testing.T) {
 	cfg := ResolveSessionConfig(&agent.AgentConfig{
-		Name:          "test-agent",
-		Runtime:       runtimeinfo.NativeRuntime,
-		Model:         "openai/gpt-4o-mini",
-		MaxIterations: 50,
+		Name:                   "test-agent",
+		Runtime:                runtimeinfo.NativeRuntime,
+		Model:                  "openai/gpt-4o-mini",
+		MaxIterations:          50,
 		AllowCustomNativeModel: true,
 	})
 	if cfg.RuntimeConfig.MaxIterations != 50 {
@@ -103,10 +110,10 @@ func TestResolveSessionConfig_MaxIterations_AgentYAML(t *testing.T) {
 func TestResolveSessionConfig_MaxIterations_EnvVar(t *testing.T) {
 	t.Setenv("TOC_MAX_ITERATIONS", "100")
 	cfg := ResolveSessionConfig(&agent.AgentConfig{
-		Name:          "test-agent",
-		Runtime:       runtimeinfo.NativeRuntime,
-		Model:         "openai/gpt-4o-mini",
-		MaxIterations: 50,
+		Name:                   "test-agent",
+		Runtime:                runtimeinfo.NativeRuntime,
+		Model:                  "openai/gpt-4o-mini",
+		MaxIterations:          50,
 		AllowCustomNativeModel: true,
 	})
 	if cfg.RuntimeConfig.MaxIterations != 100 {
@@ -117,10 +124,10 @@ func TestResolveSessionConfig_MaxIterations_EnvVar(t *testing.T) {
 func TestResolveSessionConfig_MaxIterations_CLIOverride(t *testing.T) {
 	t.Setenv("TOC_MAX_ITERATIONS", "100")
 	cfg := ResolveSessionConfig(&agent.AgentConfig{
-		Name:          "test-agent",
-		Runtime:       runtimeinfo.NativeRuntime,
-		Model:         "openai/gpt-4o-mini",
-		MaxIterations: 50,
+		Name:                   "test-agent",
+		Runtime:                runtimeinfo.NativeRuntime,
+		Model:                  "openai/gpt-4o-mini",
+		MaxIterations:          50,
 		AllowCustomNativeModel: true,
 	}, ResolveOptions{MaxIterationsOverride: 200})
 	if cfg.RuntimeConfig.MaxIterations != 200 {
@@ -131,10 +138,10 @@ func TestResolveSessionConfig_MaxIterations_CLIOverride(t *testing.T) {
 func TestResolveSessionConfig_MaxIterations_InvalidEnvIgnored(t *testing.T) {
 	t.Setenv("TOC_MAX_ITERATIONS", "notanumber")
 	cfg := ResolveSessionConfig(&agent.AgentConfig{
-		Name:          "test-agent",
-		Runtime:       runtimeinfo.NativeRuntime,
-		Model:         "openai/gpt-4o-mini",
-		MaxIterations: 50,
+		Name:                   "test-agent",
+		Runtime:                runtimeinfo.NativeRuntime,
+		Model:                  "openai/gpt-4o-mini",
+		MaxIterations:          50,
 		AllowCustomNativeModel: true,
 	})
 	if cfg.RuntimeConfig.MaxIterations != 50 {
@@ -146,5 +153,21 @@ func TestLoadSessionConfigInWorkspace_Missing(t *testing.T) {
 	_, err := LoadSessionConfigInWorkspace(t.TempDir(), "missing")
 	if !os.IsNotExist(err) {
 		t.Fatalf("expected os.IsNotExist, got %v", err)
+	}
+}
+
+func TestValidateSessionConfig_SmallModel(t *testing.T) {
+	cfg := &SessionConfig{
+		Runtime:    runtimeinfo.NativeRuntime,
+		Model:      "openai/gpt-4o-mini",
+		SmallModel: "meta-llama/unknown",
+	}
+	if err := ValidateSessionConfig(cfg); err == nil {
+		t.Fatal("expected unsupported custom small_model to fail validation")
+	}
+
+	cfg.AllowCustomNativeModel = true
+	if err := ValidateSessionConfig(cfg); err != nil {
+		t.Fatalf("expected override to allow custom small_model, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add optional `small_model` to agent and session config, with the same model validation rules as `model`
- use `small_model` for native structured compaction when configured, falling back to the primary model otherwise
- cover the new config plumbing and compaction selection with tests, and document the behavior

## Testing
- go test ./...

Closes #142