### PR TITLE
Add TodoWrite follow-up cleanup

### DIFF
--- a/internal/runtime/context_view_test.go
+++ b/internal/runtime/context_view_test.go
@@ -191,6 +191,30 @@ func TestBuildContextView_InjectsTodosBeforeWorkingSet(t *testing.T) {
 	}
 }
 
+func TestBuildContextView_SkipsNilTodos(t *testing.T) {
+	state := &State{
+		Messages: []Message{
+			{Role: "system", Content: "system prompt"},
+			{Role: "user", Content: "hello"},
+		},
+		Todos: nil,
+		WorkingSet: &WorkingSet{
+			FilesEdited: []string{"main.go"},
+		},
+	}
+
+	view := BuildContextView(state)
+	if len(view) != 3 {
+		t.Fatalf("len(view) = %d, want 3", len(view))
+	}
+	if strings.Contains(view[1].Content, "[toc-todos]") {
+		t.Fatalf("did not expect todo injection at view[1], got %q", view[1].Content)
+	}
+	if !strings.Contains(view[1].Content, "[toc-working-set]") {
+		t.Fatalf("expected working set injection at view[1], got %q", view[1].Content)
+	}
+}
+
 func TestBuildContextView_NoWorkingSet(t *testing.T) {
 	state := &State{
 		Messages: []Message{

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -408,6 +408,9 @@ func restrictNativeSubAgentTools(cfg *runtime.SessionConfig) {
 	if cfg == nil || cfg.Runtime != runtimeinfo.NativeRuntime {
 		return
 	}
+	// An empty EnabledTools list currently means "no tools" for toc-native,
+	// so there's nothing to filter. If that invariant ever changes to mean
+	// "all tools", this helper must be revisited.
 	if len(cfg.RuntimeConfig.EnabledTools) == 0 {
 		return
 	}


### PR DESCRIPTION
This follow-up adds the missing nil-todos context-view test and documents the  empty-tools invariant with an inline comment. It keeps the TodoWrite PR behavior unchanged while tightening the edge-case coverage noted in review. Verified with ok  	github.com/tiny-oc/toc/internal/runtime	(cached)
ok  	github.com/tiny-oc/toc/internal/spawn	(cached).