### PR TITLE
Fix resume args, interactive runtime, and shell parser compat

### DIFF
--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -248,7 +248,7 @@ var agentCreateCmd = &cobra.Command{
 		}
 
 		cfg := agent.AgentConfig{
-			Runtime:     runtimeinfo.DefaultRuntime,
+			Runtime:     runtimeName,
 			Name:        name,
 			Description: desc,
 			Model:       model,
@@ -271,7 +271,7 @@ var agentCreateCmd = &cobra.Command{
 		auditLog("agent.create", map[string]interface{}{
 			"agent":   name,
 			"model":   model,
-			"runtime": runtimeinfo.DefaultRuntime,
+			"runtime": runtimeName,
 		})
 
 		fmt.Println()

--- a/internal/runtime/codex.go
+++ b/internal/runtime/codex.go
@@ -261,9 +261,8 @@ func buildCodexInteractiveArgs(workDir, model string, resume bool, tocSessionID 
 	if err != nil {
 		return nil, err
 	}
-	args := []string{"resume"}
-	args = append(args, codexModelArgs(model)...)
-	args = append(args, "--dangerously-bypass-approvals-and-sandbox", conversationID)
+	args := codexModelArgs(model)
+	args = append(args, "--dangerously-bypass-approvals-and-sandbox", "resume", conversationID)
 	return args, nil
 }
 
@@ -274,13 +273,12 @@ func buildCodexExecArgs(workDir, model, prompt string, resume bool, tocSessionID
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, "resume")
 		args = append(args, codexModelArgs(model)...)
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 		if outputPath != "" {
 			args = append(args, "-o", outputPath)
 		}
-		args = append(args, conversationID, prompt)
+		args = append(args, "resume", conversationID, prompt)
 		return args, nil
 	}
 
@@ -317,7 +315,7 @@ func BuildCodexDetachedScript(helperExecutable string, opts DetachedOptions, pro
 		command += " --skip-git-repo-check"
 		command += fmt.Sprintf(" - < %q", promptPath)
 	} else {
-		command = fmt.Sprintf("codex exec resume --dangerously-bypass-approvals-and-sandbox -m %q -o %q %q - < %q",
+		command = fmt.Sprintf("codex exec --dangerously-bypass-approvals-and-sandbox -m %q -o %q resume %q - < %q",
 			opts.Model, outputTmpPath, resumeConversationID, promptPath)
 	}
 
@@ -878,7 +876,7 @@ func parseCodexRolloutLine(line []byte, pending map[string]codexRolloutFunctionC
 
 func codexRolloutCallOutputToStep(call codexRolloutFunctionCall, output string) Step {
 	switch call.Name {
-	case "shell_command", "exec_command":
+	case "shell", "shell_command", "exec_command":
 		exitCode, durationMS, body := parseCodexCommandOutput(output)
 		step := Step{
 			Type:       "tool",
@@ -904,6 +902,23 @@ func codexRolloutCallOutputToStep(call codexRolloutFunctionCall, output string) 
 }
 
 func parseCodexCommandOutput(output string) (int, int64, string) {
+	// Try structured text format first (Exit code: / Wall time: / Output:)
+	if strings.Contains(output, "Exit code:") {
+		return parseCodexCommandOutputStructured(output)
+	}
+	// Older Codex CLI versions emit a JSON-string output for "shell" calls
+	var jsonOutput struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(output), &jsonOutput); err == nil {
+		return jsonOutput.ExitCode, 0, strings.TrimSpace(jsonOutput.Output)
+	}
+	// Fall back to treating the whole string as output
+	return 0, 0, strings.TrimSpace(output)
+}
+
+func parseCodexCommandOutputStructured(output string) (int, int64, string) {
 	lines := strings.Split(output, "\n")
 	exitCode := 0
 	var durationMS int64

--- a/internal/runtime/codex_test.go
+++ b/internal/runtime/codex_test.go
@@ -122,6 +122,72 @@ func TestParseCodexExecLog(t *testing.T) {
 	}
 }
 
+func TestParseCodexRolloutOlderShellFormat(t *testing.T) {
+	provider, err := Get(runtimeinfo.CodexRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Older Codex CLI emits "shell" function calls with JSON-string output
+	logPath := filepath.Join(t.TempDir(), codexEventsFile)
+	lines := []map[string]interface{}{
+		{
+			"timestamp": "2026-03-27T11:00:00Z",
+			"type":      "session_meta",
+			"payload": map[string]interface{}{
+				"id":        "codex-thread-old",
+				"timestamp": "2026-03-27T11:00:00Z",
+				"cwd":       "/tmp/test",
+			},
+		},
+		{
+			"timestamp": "2026-03-27T11:00:01Z",
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":      "function_call",
+				"name":      "shell",
+				"arguments": `{"cmd":"ls -la"}`,
+				"call_id":   "call-old-1",
+			},
+		},
+		{
+			"timestamp": "2026-03-27T11:00:02Z",
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":    "function_call_output",
+				"call_id": "call-old-1",
+				"output":  `{"output":"total 8\ndrwxr-xr-x  2 user user 4096 Mar 27 11:00 .\n","exit_code":0}`,
+			},
+		},
+	}
+	var content []byte
+	for _, line := range lines {
+		data, err := json.Marshal(line)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content = append(content, data...)
+		content = append(content, '\n')
+	}
+	if err := os.WriteFile(logPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := provider.ParseSessionLog(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Steps) != 1 {
+		t.Fatalf("expected 1 parsed step, got %d: %#v", len(parsed.Steps), parsed.Steps)
+	}
+	if parsed.Steps[0].Tool != "Bash" || parsed.Steps[0].Command != "ls -la" {
+		t.Fatalf("expected bash step from older shell format, got %#v", parsed.Steps[0])
+	}
+	if parsed.Steps[0].ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", parsed.Steps[0].ExitCode)
+	}
+}
+
 func TestParseCodexRolloutLogAndDiscoverByWorkspace(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
Addresses all three review comments on #154:

- **Resume arg ordering**: Moves `-m`, `-o`, `--dangerously-bypass-approvals-and-sandbox` flags before the `resume` subcommand in `buildCodexExecArgs`, `buildCodexInteractiveArgs`, and `BuildCodexDetachedScript` so codex-cli 0.46.0 accepts them
- **Interactive agent create**: Uses the selected `runtimeName` instead of hardcoded `runtimeinfo.DefaultRuntime` in the config and audit log for the interactive flow
- **Rollout parser compat**: Adds `shell` as a recognized function call name alongside `shell_command`/`exec_command`, and handles the older JSON-string output format emitted by older Codex CLI versions

## Test plan
- [x] Added `TestParseCodexRolloutOlderShellFormat` covering the older `shell` function call with JSON output
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)