### PR TITLE
Show estimated cost next to token count in toc status

### DIFF
--- a/cmd/status_tui.go
+++ b/cmd/status_tui.go
@@ -99,6 +99,12 @@ func (m statusModel) View() tea.View {
 	b.WriteString(fmt.Sprintf("  %s %s\n", bold("Config:"), dim(config.TocDir()+"/")))
 	b.WriteString("\n")
 
+	// Build agent name → model map for cost lookups.
+	agentModel := make(map[string]string, len(m.agents))
+	for _, a := range m.agents {
+		agentModel[a.Name] = a.Model
+	}
+
 	// Token totals per agent
 	agentTokens := make(map[string]usage.TokenUsage)
 	var totalTokens usage.TokenUsage
@@ -134,9 +140,15 @@ func (m statusModel) View() tea.View {
 				if a.Description != "" {
 					desc = " " + dim("— "+a.Description)
 				}
-				tokenStr := agentTokens[a.Name].FormatTotal()
+				agTok := agentTokens[a.Name]
+				tokenStr := agTok.FormatTotal()
 				if tokenStr != "" {
-					desc += " " + dim("["+tokenStr+"]")
+					costStr := usage.FormatCost(usage.EstimateCost(a.Model, agTok))
+					bracket := tokenStr
+					if costStr != "" {
+						bracket += "  " + costStr
+					}
+					desc += " " + dim("["+bracket+"]")
 				}
 				b.WriteString(fmt.Sprintf("    %s %s %s%s\n", green("✓"), cyan(a.Name), dim(a.Model), desc))
 			} else {
@@ -221,7 +233,12 @@ func (m statusModel) View() tea.View {
 			tokenStr := tokens.FormatTotal()
 			tokenCol := ""
 			if tokenStr != "" {
-				tokenCol = "  " + dim(tokenStr)
+				costStr := usage.FormatCost(usage.EstimateCost(agentModel[s.Agent], tokens))
+				if costStr != "" {
+					tokenCol = "  " + dim(tokenStr+"  "+costStr)
+				} else {
+					tokenCol = "  " + dim(tokenStr)
+				}
 			}
 
 			nameCol := ""

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -26,6 +26,18 @@ func (u TokenUsage) Total() int64 {
 	return u.InputTokens + u.OutputTokens + u.CacheRead + u.CacheCreate
 }
 
+// FormatCost returns a human-readable USD cost string, e.g. "~$0.04".
+// Returns empty string if cost is zero or the model has no pricing data.
+func FormatCost(cost float64) string {
+	if cost <= 0 {
+		return ""
+	}
+	if cost < 0.01 {
+		return fmt.Sprintf("~$%.4f", cost)
+	}
+	return fmt.Sprintf("~$%.2f", cost)
+}
+
 // FormatTotal returns a human-readable token count.
 func (u TokenUsage) FormatTotal() string {
 	t := u.Total()


### PR DESCRIPTION
## Summary

- Adds `FormatCost(float64) string` to the `usage` package (returns `~$0.04` / `~$1.23`, empty when zero)
- Wires `EstimateCost` into the status TUI for both the agent list and session rows
- Builds a `name → model` map from loaded agents so session rows can look up pricing without a model field on the session record

## Output

Before:
```
✓ superfounder-cto anthropic/claude-opus-4.6 — ... [240.4k tokens]
○ completed  superfounder-product-founder  1 day ago  9914463a  207.2k tokens
```

After:
```
✓ superfounder-cto anthropic/claude-opus-4.6 — ... [240.4k tokens  ~$1.20]
○ completed  superfounder-product-founder  1 day ago  9914463a  207.2k tokens  ~$1.04
```

Cost is silently omitted when the model has no entry in the pricing table (e.g. `claude-code` agents using `default` or `sonnet` shorthands).

## Test plan
- [ ] `go test ./internal/usage/... ./cmd/...` passes
- [ ] Run `toc status` in a workspace with toc-native sessions and confirm cost appears next to token counts
- [ ] Confirm no cost shown for claude-code agents with shorthand model names

🤖 Generated with [Claude Code](https://claude.com/claude-code)