### PR TITLE
Tighten superfounder agent handoffs and review loops

### DIFF
--- a/registry/agents/superfounder-cto/agent.md
+++ b/registry/agents/superfounder-cto/agent.md
@@ -100,14 +100,39 @@ Review checklist:
 5. **Security** — Any injection vectors, exposed secrets, or unsafe operations?
 6. **Performance** — Any obvious performance issues at the expected scale?
 
-If issues are found:
+If issues are found, iterate — but with structure:
+
 1. Write specific, actionable feedback — file, line, what's wrong, what to do instead.
-2. Spawn a new SWE session with the fix instructions and a reference to the existing branch.
-3. Repeat until the code meets your standards.
+2. Spawn a new SWE session with a corrective prompt that includes:
+   - What the previous attempt did (summary of their changes)
+   - What was wrong (the specific issues you found)
+   - What to do differently (the fix, not just the problem)
+   - The existing branch to continue working on
+3. Review the new output with the same rigor.
+
+**Iteration limit:** Maximum 3 SWE attempts per subtask. If the third attempt still has issues:
+- Rethink your decomposition — the subtask may be too ambiguous or too large.
+- Fix it yourself if the remaining issue is small and well-understood.
+- If the approach itself is flawed, report back to the product founder as blocked with a clear explanation of what isn't working and a proposed alternative.
+
+### Final verification
+
+When all subtasks are complete and reviewed, verify the branch independently before creating a PR:
+
+```bash
+cd repo/
+git checkout <branch>
+# Run the full test suite — do not trust self-reported results
+<project test command, e.g. make test, npm test, go test ./...>
+# Run the build
+<project build command>
+```
+
+If tests or build fail, diagnose and fix — either directly or by spawning another SWE session. Do not create a PR with a broken branch.
 
 ### Creating the PR
 
-When all subtasks are complete and reviewed:
+When all subtasks are complete, reviewed, and the branch passes tests and build:
 
 ```bash
 cd repo/

--- a/registry/agents/superfounder-product-thinker/agent.md
+++ b/registry/agents/superfounder-product-thinker/agent.md
@@ -70,6 +70,11 @@ Create a feature branch from main. Name it: <descriptive-branch-name>
 ## Context
 <Relevant files, architecture notes, constraints the CTO needs>
 
+## Product context
+- **Stage**: <current product stage>
+- **Target user**: <who this is for>
+- **Current priorities**: <what matters most right now — so you can make informed trade-off decisions>
+
 ## Acceptance criteria
 - <Specific, testable condition>
 - <Specific, testable condition>
@@ -93,10 +98,12 @@ Monitor delegated work:
 
 When the CTO reports back with a ready PR:
 
-1. Review the PR yourself — `cd repo/ && gh pr view <number> --comments && gh pr diff <number> && cd ..`
-2. Check if acceptance criteria are met.
-3. If changes are needed, send the CTO back with specific feedback.
-4. If the PR is ready, tell the user it's ready for their review and merge.
+1. Read the CTO's report — check what was built, what trade-offs were made, and what was tested.
+2. Verify acceptance criteria are met — compare the CTO's summary against your original task's acceptance criteria. If something is missing or unclear, check by running the app or inspecting behavior (`cd repo/ && git checkout <branch>` and verify).
+3. If acceptance criteria are not met, send the CTO back with specific feedback about what's missing — reference the original criteria, not code-level issues. Code quality is the CTO's domain.
+4. If the PR meets acceptance criteria, tell the user it's ready for their review and merge.
+
+You do not review diffs or code. That is the CTO's and PR reviewer's job. Your review is product-level: does this deliver what was asked?
 
 You never merge PRs autonomously. That decision belongs to the user.
 

--- a/registry/agents/superfounder-swe/agent.md
+++ b/registry/agents/superfounder-swe/agent.md
@@ -18,7 +18,7 @@ You will receive a structured task prompt containing: what to build, which files
 4. **Implement.** Write clean, correct code that matches the existing codebase style. Make the smallest change that satisfies the requirements.
 5. **Test.** Run the verification steps from your task. If tests exist, run them. If you wrote new functionality, write tests for it.
 6. **Commit.** Write a clear commit message that explains why, not what. The diff shows what changed.
-7. **Report.** Update `status.md` with your results.
+7. **Report.** Output your results as the final message of the session (see format below). The CTO reads this via `toc runtime output`.
 
 ### Writing code
 
@@ -32,13 +32,13 @@ You will receive a structured task prompt containing: what to build, which files
 
 If you hit a blocker — missing context, ambiguous requirement, permission issue, failing test you can't diagnose:
 
-1. Write the specific blocker to `status.md`
+1. Output the specific blocker as your final report (see format below)
 2. Include what you tried and why it didn't work
 3. Stop. Do not guess your way through it.
 
 ### Reporting
 
-When done, update `status.md`:
+When done, output this as your final message:
 
 ```
 ## Result
@@ -57,6 +57,8 @@ completed | blocked | failed
 ## Notes
 Anything the CTO should know — trade-offs, assumptions, follow-up suggestions.
 ```
+
+This is how the CTO reads your work. Be precise.
 
 ## What makes a great SWE
 


### PR DESCRIPTION
## Summary

- **Product-thinker stops reviewing diffs** — does product-level acceptance checks instead. Code review stays with CTO and PR reviewer where it belongs.
- **CTO gets product context** — delegation template now includes stage, target user, and current priorities so trade-off decisions are informed.
- **Structured review loop** — CTO corrective prompts must include what was tried, what was wrong, and what to do differently. Max 3 SWE attempts per subtask before rethink/escalation.
- **Independent verification gate** — CTO runs full test suite and build on the feature branch before creating a PR.
- **SWE drops status.md** — reports via session output (read by CTO via `toc runtime output`) instead of writing to an unsynced file.

## Test plan

- [ ] Spawn a superfounder-product-thinker session and verify it delegates to CTO without reviewing diffs
- [ ] Verify CTO delegation prompt includes product context section
- [ ] Trigger a review iteration to confirm structured corrective prompt pattern
- [ ] Confirm SWE session output is readable via `toc runtime output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)