### PR TITLE
Fix GLM-5 MaxOutputTokens exceeding context window, add InputBudget guard

### DIFF
--- a/internal/runtime/context_budgeter.go
+++ b/internal/runtime/context_budgeter.go
@@ -45,7 +45,13 @@ func NewContextBudgeter(profile runtimeinfo.NativeModelProfile) *ContextBudgeter
 // InputBudget returns the maximum number of input tokens available for
 // message history (context window minus output reservation minus buffer).
 func (b *ContextBudgeter) InputBudget() int {
-	budget := b.ContextWindow - b.MaxOutput - b.ReservedBuffer
+	// Guard: MaxOutput must not exceed the context window (misconfigured profiles
+	// would produce a negative budget and silently floor sessions at 1024).
+	maxOut := b.MaxOutput
+	if maxOut > b.ContextWindow {
+		maxOut = b.ContextWindow / 2
+	}
+	budget := b.ContextWindow - maxOut - b.ReservedBuffer
 	if budget < 1024 {
 		return 1024
 	}

--- a/internal/runtimeinfo/native_models.go
+++ b/internal/runtimeinfo/native_models.go
@@ -88,7 +88,7 @@ var nativeModelProfiles = []NativeModelProfile{
 		SupportsTools:     true,
 		SupportsStreaming: true,
 		ContextWindow:     80000,
-		MaxOutputTokens:   131072,
+		MaxOutputTokens:   8192,
 		ReservedBuffer:    4096,
 	},
 	{


### PR DESCRIPTION
## Root cause

Session `8521b01c` failed immediately with:
> context exceeds model budget (2209 tokens estimated, 1024 available) after emergency compaction

The `z-ai/glm-5` profile had `MaxOutputTokens: 131072` on a `ContextWindow: 80000`. The budget calculation:

```
InputBudget = 80000 - 131072 - 4096 = -55168
```

Falls below the 1024 minimum floor, so `InputBudget()` returns 1024. The system prompt alone is ~2209 tokens, which exceeds 1024 → immediate fatal error before any work starts.

## Fix

1. **Correct the GLM-5 profile**: `MaxOutputTokens: 131072 → 8192` (appropriate for an 80k context model; the 131072 value was likely copy-pasted from a larger model).

2. **Add a defensive guard in `InputBudget`**: if `MaxOutput > ContextWindow`, cap it at `ContextWindow / 2`. This prevents a misconfigured future profile from silently destroying sessions.

## Result

GLM-5 `InputBudget` is now `80000 - 8192 - 4096 = 67712`, which is the correct usable context for that model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)