### PR TITLE
Fix toc stop: write PID files for interactive sessions

### DIFF
--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,7 +96,9 @@ func (claudeProvider) LaunchInteractive(opts LaunchOptions) error {
 
 	// Write PID file so `toc stop` can find and terminate the process.
 	pidPath := filepath.Join(opts.Dir, "toc-pid.txt")
-	_ = os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644)
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0600); err != nil {
+		log.Printf("warning: failed to write PID file %s: %v", pidPath, err)
+	}
 	defer os.Remove(pidPath)
 
 	if err := cmd.Wait(); err != nil {

--- a/internal/runtime/native.go
+++ b/internal/runtime/native.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -142,7 +143,9 @@ func (nativeProvider) LaunchInteractive(opts LaunchOptions) error {
 
 	// Write PID file so `toc stop` can find and terminate the process.
 	pidPath := filepath.Join(opts.Dir, "toc-pid.txt")
-	_ = os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644)
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0600); err != nil {
+		log.Printf("warning: failed to write PID file %s: %v", pidPath, err)
+	}
 	defer os.Remove(pidPath)
 
 	if err := cmd.Wait(); err != nil {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -383,10 +383,15 @@ func TestStopByPrefix_AmbiguousPrefix(t *testing.T) {
 		{ID: "f74e0d70-aaaa-0000-0000-000000000001", Agent: "a", WorkspacePath: t.TempDir(), Status: StatusActive},
 		{ID: "f74e0d70-bbbb-0000-0000-000000000002", Agent: "b", WorkspacePath: t.TempDir(), Status: StatusActive},
 	}}
-	data, _ := yaml.Marshal(sf)
-	os.WriteFile(filepath.Join(tocDir, "sessions.yaml"), data, 0600)
+	data, err := yaml.Marshal(sf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tocDir, "sessions.yaml"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := FindByIDPrefixInWorkspace(wsDir, "f74e0d70")
+	_, err = FindByIDPrefixInWorkspace(wsDir, "f74e0d70")
 	if err == nil {
 		t.Fatal("expected ambiguous prefix error, got nil")
 	}


### PR DESCRIPTION
## Summary

- `toc stop <session-id>` always reported "no PID file found" because interactive sessions (`LaunchInteractive`) never wrote `toc-pid.txt` — only detached sub-agent sessions did via their shell wrapper scripts
- Split `cmd.Run()` into `cmd.Start()` + `cmd.Wait()` in both native and claude providers, writing the child PID to `toc-pid.txt` between them; the file is cleaned up on normal exit via `defer`
- Added tests covering prefix-based session resolution + PID file reading, and ambiguous prefix error handling

## Test plan

- [x] `go test ./...` passes (all existing + new tests)
- [ ] Manual: `toc agent spawn <name>`, then from another terminal `toc stop <8-char-prefix>` — process should be terminated
- [ ] Manual: verify PID file is cleaned up after session exits normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)