### PR TITLE
Add toc-native runtime support for anthropic/claude-sonnet-4.6

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -127,6 +127,7 @@ Native runtime models are served through OpenRouter. Supported profiles:
 | `openai/gpt-4o-mini` | GPT-4o Mini (default) |
 | `openai/gpt-4o` | GPT-4o |
 | `anthropic/claude-sonnet-4` | Claude Sonnet 4 |
+| `anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 |
 
 To use a model outside this set, opt in explicitly:
 

--- a/internal/runtimeinfo/native_models.go
+++ b/internal/runtimeinfo/native_models.go
@@ -72,6 +72,16 @@ var nativeModelProfiles = []NativeModelProfile{
 		ReservedBuffer:    8192,
 	},
 	{
+		ID:                "anthropic/claude-sonnet-4.6",
+		Label:             "Claude Sonnet 4.6",
+		Description:       "Anthropic mid-tier model with strong coding and reasoning at lower cost",
+		SupportsTools:     true,
+		SupportsStreaming: true,
+		ContextWindow:     200000,
+		MaxOutputTokens:   16384,
+		ReservedBuffer:    4096,
+	},
+	{
 		ID:                "anthropic/claude-opus-4.6",
 		Label:             "Claude Opus 4.6",
 		Description:       "Anthropic flagship model for coding and agentic workflows with 1M context",

--- a/internal/runtimeinfo/native_models_test.go
+++ b/internal/runtimeinfo/native_models_test.go
@@ -32,6 +32,22 @@ func TestResolveNativeProfileUnknownModel(t *testing.T) {
 	}
 }
 
+func TestLookupNativeProfileClaudeSonnet46(t *testing.T) {
+	profile, ok := LookupNativeProfile("anthropic/claude-sonnet-4.6")
+	if !ok {
+		t.Fatal("expected to find anthropic/claude-sonnet-4.6 profile")
+	}
+	if profile.Label != "Claude Sonnet 4.6" {
+		t.Fatalf("Label = %q, want %q", profile.Label, "Claude Sonnet 4.6")
+	}
+	if profile.ContextWindow != 200000 {
+		t.Fatalf("ContextWindow = %d, want 200000", profile.ContextWindow)
+	}
+	if !profile.SupportsTools {
+		t.Fatal("expected SupportsTools = true")
+	}
+}
+
 func TestValidateNativeModel_RejectsUnknownWithoutOverride(t *testing.T) {
 	err := ValidateNativeModel("meta-llama/unknown", false)
 	if err == nil {

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -41,6 +41,12 @@ var modelPricing = map[string]ModelPricing{
 		CacheReadPerToken:  1.75 / 1_000_000, // no cache discount listed
 		CacheWritePerToken: 1.75 / 1_000_000,
 	},
+	"anthropic/claude-sonnet-4.6": {
+		InputPerToken:      3.00 / 1_000_000,
+		OutputPerToken:     15.00 / 1_000_000,
+		CacheReadPerToken:  0.30 / 1_000_000,
+		CacheWritePerToken: 3.75 / 1_000_000,
+	},
 	"anthropic/claude-opus-4.6": {
 		InputPerToken:      5.00 / 1_000_000,
 		OutputPerToken:     25.00 / 1_000_000,

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -50,6 +50,26 @@ func TestEstimateCostCodex(t *testing.T) {
 	}
 }
 
+func TestEstimateCostClaudeSonnet46(t *testing.T) {
+	tokens := TokenUsage{
+		InputTokens:  1_000_000,
+		OutputTokens: 100_000,
+		CacheRead:    500_000,
+		CacheCreate:  50_000,
+	}
+	cost := EstimateCost("anthropic/claude-sonnet-4.6", tokens)
+	// claude-sonnet-4.6: input=$3/M, output=$15/M, cache_read=$0.30/M, cache_write=$3.75/M
+	// non-cached: (1M - 500k - 50k) * 3/M = 1.35
+	// output: 100k * 15/M = 1.50
+	// cache_read: 500k * 0.30/M = 0.15
+	// cache_write: 50k * 3.75/M = 0.1875
+	// total = 3.1875
+	expected := 3.1875
+	if math.Abs(cost-expected) > 0.001 {
+		t.Fatalf("cost = %f, expected %f", cost, expected)
+	}
+}
+
 func TestLookupPricing(t *testing.T) {
 	if _, ok := LookupPricing("openai/gpt-5.4"); !ok {
 		t.Fatal("expected pricing for gpt-5.4")


### PR DESCRIPTION
## Summary
- Register `anthropic/claude-sonnet-4.6` as a supported native model profile (200k context, 16k max output, tool calling, streaming)
- Add OpenRouter pricing ($3/M input, $15/M output, with cache tier discounts)
- Add tests for profile lookup and cost estimation
- Update docs/runtimes.md model table

## Test plan
- [x] `TestLookupNativeProfileClaudeSonnet46` — verifies profile exists with correct label, context window, and tool support
- [x] `TestEstimateCostClaudeSonnet46` — verifies cost calculation with cache read/write breakdown
- [x] Full test suite for `internal/runtimeinfo` and `internal/usage` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)