### PR TITLE
Add official toc-native support for anthropic/claude-opus-4.6

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -128,6 +128,7 @@ Native runtime models are served through OpenRouter. Supported profiles:
 | `openai/gpt-4o` | GPT-4o |
 | `anthropic/claude-sonnet-4` | Claude Sonnet 4 |
 | `anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 |
+| `anthropic/claude-opus-4.6` | Claude Opus 4.6 |
 
 To use a model outside this set, opt in explicitly:
 
@@ -192,7 +193,7 @@ Session config defaults:
 - Keep recent: 12 messages (retained after compaction)
 - Max continuation: ~6,000 characters
 
-For models with known context windows (GPT-4o: 128K, Claude Sonnet 4: 200K), token budgets are computed automatically. Custom models use a conservative 128K default.
+For models with known context windows (GPT-4o: 128K, Claude Sonnet 4: 200K, Claude Opus 4.6: 200K), token budgets are computed automatically. Custom models use a conservative 128K default.
 
 ## Choosing a runtime
 

--- a/internal/runtimeinfo/native_models.go
+++ b/internal/runtimeinfo/native_models.go
@@ -84,12 +84,12 @@ var nativeModelProfiles = []NativeModelProfile{
 	{
 		ID:                "anthropic/claude-opus-4.6",
 		Label:             "Claude Opus 4.6",
-		Description:       "Anthropic flagship model for coding and agentic workflows with 1M context",
+		Description:       "Anthropic flagship model for complex coding and agentic workflows",
 		SupportsTools:     true,
 		SupportsStreaming: true,
-		ContextWindow:     1000000,
-		MaxOutputTokens:   128000,
-		ReservedBuffer:    8192,
+		ContextWindow:     200000,
+		MaxOutputTokens:   32768,
+		ReservedBuffer:    4096,
 	},
 	{
 		ID:                "z-ai/glm-5",

--- a/internal/runtimeinfo/native_models_test.go
+++ b/internal/runtimeinfo/native_models_test.go
@@ -48,6 +48,25 @@ func TestLookupNativeProfileClaudeSonnet46(t *testing.T) {
 	}
 }
 
+func TestLookupNativeProfileClaudeOpus46(t *testing.T) {
+	profile, ok := LookupNativeProfile("anthropic/claude-opus-4.6")
+	if !ok {
+		t.Fatal("expected to find anthropic/claude-opus-4.6 profile")
+	}
+	if profile.Label != "Claude Opus 4.6" {
+		t.Fatalf("Label = %q, want %q", profile.Label, "Claude Opus 4.6")
+	}
+	if profile.ContextWindow != 200000 {
+		t.Fatalf("ContextWindow = %d, want 200000", profile.ContextWindow)
+	}
+	if profile.MaxOutputTokens != 32768 {
+		t.Fatalf("MaxOutputTokens = %d, want 32768", profile.MaxOutputTokens)
+	}
+	if !profile.SupportsTools {
+		t.Fatal("expected SupportsTools = true")
+	}
+}
+
 func TestValidateNativeModel_RejectsUnknownWithoutOverride(t *testing.T) {
 	err := ValidateNativeModel("meta-llama/unknown", false)
 	if err == nil {

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -48,10 +48,10 @@ var modelPricing = map[string]ModelPricing{
 		CacheWritePerToken: 3.75 / 1_000_000,
 	},
 	"anthropic/claude-opus-4.6": {
-		InputPerToken:      5.00 / 1_000_000,
-		OutputPerToken:     25.00 / 1_000_000,
-		CacheReadPerToken:  0.50 / 1_000_000,
-		CacheWritePerToken: 6.25 / 1_000_000,
+		InputPerToken:      15.00 / 1_000_000,
+		OutputPerToken:     75.00 / 1_000_000,
+		CacheReadPerToken:  1.50 / 1_000_000,
+		CacheWritePerToken: 18.75 / 1_000_000,
 	},
 	"z-ai/glm-5": {
 		InputPerToken:      0.72 / 1_000_000,

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -70,6 +70,26 @@ func TestEstimateCostClaudeSonnet46(t *testing.T) {
 	}
 }
 
+func TestEstimateCostClaudeOpus46(t *testing.T) {
+	tokens := TokenUsage{
+		InputTokens:  1_000_000,
+		OutputTokens: 100_000,
+		CacheRead:    500_000,
+		CacheCreate:  50_000,
+	}
+	cost := EstimateCost("anthropic/claude-opus-4.6", tokens)
+	// claude-opus-4.6: input=$15/M, output=$75/M, cache_read=$1.50/M, cache_write=$18.75/M
+	// non-cached: (1M - 500k - 50k) * 15/M = 6.75
+	// output: 100k * 75/M = 7.50
+	// cache_read: 500k * 1.50/M = 0.75
+	// cache_write: 50k * 18.75/M = 0.9375
+	// total = 15.9375
+	expected := 15.9375
+	if math.Abs(cost-expected) > 0.001 {
+		t.Fatalf("cost = %f, expected %f", cost, expected)
+	}
+}
+
 func TestLookupPricing(t *testing.T) {
 	if _, ok := LookupPricing("openai/gpt-5.4"); !ok {
 		t.Fatal("expected pricing for gpt-5.4")


### PR DESCRIPTION
## Summary
- Update `anthropic/claude-opus-4.6` model profile to official specs: 200k context window, 32k max output tokens
- Set pricing to $15/M input, $75/M output (with proportional cache pricing)
- Add model lookup and cost estimation tests
- Add Opus 4.6 to the supported models table in runtimes docs

## Test plan
- [x] `go test ./internal/runtimeinfo/` — profile lookup and validation tests pass
- [x] `go test ./internal/usage/` — cost estimation test verifies token math

🤖 Generated with [Claude Code](https://claude.com/claude-code)