### PR TITLE
Enable web access for content-writer agent

### DIFF
--- a/registry/agents/content-writer/oc-agent.yaml
+++ b/registry/agents/content-writer/oc-agent.yaml
@@ -14,3 +14,5 @@ permissions:
     read: "on"
     write: "on"
     execute: "off"
+  network:
+    web: "on"


### PR DESCRIPTION
## Summary
- Add `network.web: "on"` to content-writer permissions so it can fetch URLs (e.g. blog posts for voice profiling)
- Network permissions default to `off`, so WebFetch was blocked without this

## Test plan
- [ ] Spawn content-writer, send it a URL, confirm WebFetch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)