### PR TITLE
Fix Alt+Backspace word deletion in interactive CLI

### DIFF
--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -198,9 +198,8 @@ func RunNativeSession(opts NativeRunOptions, stdin io.Reader, stdout io.Writer) 
 			if lineEditor != nil {
 				prompt := ui.UserPromptPrefix(opts.Agent)
 				fmt.Fprint(stdout, prompt)
-				lineEditor.Prompt = prompt
 				go func() {
-					line, err := lineEditor.ReadLine()
+					line, err := lineEditor.ReadLine(prompt)
 					readCh <- readResult{line, err}
 				}()
 			} else {

--- a/internal/ui/lineedit.go
+++ b/internal/ui/lineedit.go
@@ -16,13 +16,12 @@ import (
 // Alt+Backspace (ESC DEL) for word deletion in addition to standard
 // editing keys (Backspace, Ctrl+W, Ctrl+U, Ctrl+C, Ctrl+D).
 type LineEditor struct {
-	In     *os.File
-	Out    io.Writer
-	Prompt string // prompt string reprinted on redraw
+	In  *os.File
+	Out io.Writer
 
 	mu       sync.Mutex
-	buf      []byte       // current line buffer, guarded by mu
-	oldState *term.State  // saved terminal state from EnterRawMode
+	buf      []byte      // snapshot of line buffer for external readers, guarded by mu
+	oldState *term.State // saved terminal state from EnterRawMode, guarded by mu
 }
 
 // errInterrupt is returned when the user presses Ctrl+C.
@@ -50,8 +49,10 @@ func (le *LineEditor) EnterRawMode() error {
 }
 
 // RestoreMode restores the terminal to the state saved by EnterRawMode.
-// It is safe to call multiple times.
+// It is safe to call concurrently and multiple times.
 func (le *LineEditor) RestoreMode() {
+	le.mu.Lock()
+	defer le.mu.Unlock()
 	if le.oldState != nil {
 		term.Restore(le.In.Fd(), le.oldState)
 		le.oldState = nil
@@ -59,14 +60,16 @@ func (le *LineEditor) RestoreMode() {
 }
 
 // ReadLine reads one line of input. The caller must have already called
-// EnterRawMode. It returns the line (without trailing newline) or an error.
-// On Ctrl+C it returns errInterrupt; on Ctrl+D at an empty line it returns io.EOF.
-func (le *LineEditor) ReadLine() (string, error) {
+// EnterRawMode. The prompt string is used when redrawing the line (e.g.
+// after word deletion). It returns the line (without trailing newline)
+// or an error. On Ctrl+C it returns errInterrupt; on Ctrl+D at an empty
+// line it returns io.EOF.
+func (le *LineEditor) ReadLine(prompt string) (string, error) {
 	le.mu.Lock()
 	le.buf = le.buf[:0]
 	le.mu.Unlock()
 
-	return readLineRaw(le.In, le.Out, le.Prompt, le)
+	return readLineRaw(le.In, le.Out, prompt, le)
 }
 
 // Buffer returns a copy of the current in-progress input. This is safe
@@ -128,6 +131,10 @@ func readLineRaw(r io.Reader, w io.Writer, prompt string, le *LineEditor) (strin
 				fmt.Fprint(w, "\r\n")
 				return "", io.EOF
 			}
+			// Non-empty buffer: ignore. We don't support cursor movement,
+			// so delete-char-under-cursor (readline default) is not applicable.
+			// Flushing the partial buffer would be surprising. Silently
+			// ignoring matches the behavior of simple line editors.
 
 		case b == 0x17: // Ctrl+W — delete word backward
 			buf = deleteWordBackward(buf)
@@ -166,9 +173,29 @@ func readLineRaw(r io.Reader, w io.Writer, prompt string, le *LineEditor) (strin
 			}
 
 		case b >= 0x20: // Printable ASCII and start of UTF-8 sequences
-			buf = append(buf, b)
-			syncBuf()
-			w.Write([]byte{b})
+			if b < 0x80 {
+				// Single-byte ASCII character.
+				buf = append(buf, b)
+				syncBuf()
+				w.Write([]byte{b})
+			} else {
+				// Multi-byte UTF-8: unread the leading byte and use
+				// ReadRune to collect the complete character.
+				br.UnreadByte()
+				r, size, err := br.ReadRune()
+				if err != nil {
+					return string(buf), err
+				}
+				if r == utf8.RuneError && size == 1 {
+					// Invalid UTF-8 byte — skip it.
+					continue
+				}
+				var rBuf [utf8.UTFMax]byte
+				n := utf8.EncodeRune(rBuf[:], r)
+				buf = append(buf, rBuf[:n]...)
+				syncBuf()
+				w.Write(rBuf[:n])
+			}
 
 		default:
 			// Other control characters: ignore
@@ -193,8 +220,16 @@ func discardEscapeSequence(br *bufio.Reader) {
 	if err != nil {
 		return
 	}
+	if next == 'O' {
+		// SS3 sequence (e.g. ESC O H for Home, ESC O F for End).
+		// Consume the final byte to avoid leaking it into input.
+		if br.Buffered() > 0 {
+			br.ReadByte()
+		}
+		return
+	}
 	if next != '[' {
-		// Not a CSI sequence; single-char escape — already consumed.
+		// Not a CSI or SS3 sequence; single-char escape — already consumed.
 		return
 	}
 	// CSI: read until a final byte (0x40-0x7E), but only from what's

--- a/internal/ui/lineedit_test.go
+++ b/internal/ui/lineedit_test.go
@@ -121,6 +121,83 @@ func TestReadLineRawTruncatedCSIDoesNotBlock(t *testing.T) {
 	}
 }
 
+func TestReadLineRawUTF8RoundTrip(t *testing.T) {
+	// Multi-byte UTF-8 characters must round-trip correctly through the
+	// line editor: buffer content should match input, and output should
+	// contain the complete characters (not individual bytes).
+	input := "café naïve 日本語"
+	in := bytes.NewReader(append([]byte(input), '\r'))
+	var out bytes.Buffer
+
+	line, err := readLineRaw(in, &out, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != input {
+		t.Errorf("buffer: got %q, want %q", line, input)
+	}
+	// The output should contain the echoed characters (may also contain
+	// \r\n from Enter). Verify the input string appears in the output.
+	if !bytes.Contains(out.Bytes(), []byte(input)) {
+		t.Errorf("output %q does not contain %q", out.String(), input)
+	}
+}
+
+func TestReadLineRawUTF8Backspace(t *testing.T) {
+	// Backspace over a multi-byte character should remove the whole rune.
+	// "café" + backspace should yield "caf".
+	in := bytes.NewReader([]byte("café\x7f\r"))
+	var out bytes.Buffer
+
+	line, err := readLineRaw(in, &out, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "caf" {
+		t.Errorf("got %q, want %q", line, "caf")
+	}
+}
+
+func TestReadLineRawSS3Sequence(t *testing.T) {
+	// SS3 sequences like ESC O H (Home) should be fully consumed without
+	// leaking the final byte into the input buffer.
+	in := bytes.NewReader([]byte("ab\x1bOHcd\r"))
+	var out bytes.Buffer
+
+	line, err := readLineRaw(in, &out, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "abcd" {
+		t.Errorf("got %q, want %q", line, "abcd")
+	}
+}
+
+func TestBufferConcurrent(t *testing.T) {
+	// Exercise concurrent Buffer() access with ReadLine to verify mutex
+	// safety. Run with -race to detect data races.
+	r, w := io.Pipe()
+	var out bytes.Buffer
+	le := &LineEditor{In: nil, Out: &out}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// readLineRaw accepts any io.Reader, so we can use the pipe
+		// reader directly without a real *os.File.
+		readLineRaw(r, &out, "", le)
+	}()
+
+	// Write bytes slowly while concurrently reading Buffer().
+	input := []byte("hello world\r")
+	for _, b := range input {
+		w.Write([]byte{b})
+		// Concurrent read — the main thing is that -race doesn't fire.
+		le.Buffer()
+	}
+	<-done
+}
+
 func TestDeleteWordBackward(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary

- **Root cause**: The interactive prompt used `bufio.ReadString('\n')` in cooked terminal mode. Alt+Backspace sends `ESC DEL` (0x1b 0x7f), which the cooked-mode line discipline doesn't interpret as word deletion — it either ignores the ESC or treats DEL as single-char backspace.
- **Fix**: Added a raw-mode `LineEditor` (`internal/ui/lineedit.go`) that reads byte-by-byte and handles Alt+Backspace (ESC DEL), Ctrl+W, Ctrl+U, Ctrl+H, and Ctrl+C/Ctrl+D. The native runner uses this for TTY input while keeping the `bufio.NewReader` path for non-TTY (pipes, tests).
- Escape sequences from arrow keys and other special keys are properly discarded to avoid echoing garbage.

## Test plan

- [x] Unit tests for `readLineRaw` covering: simple input, backspace, Alt+Backspace word delete, Ctrl+W word delete, Ctrl+C interrupt, Ctrl+D EOF, Ctrl+U kill line, multiple consecutive Alt+Backspace
- [x] Unit tests for `deleteWordBackward` with various edge cases (trailing spaces, empty input, single word)
- [x] All existing `ui` and `native_runner` tests pass
- [x] Full project builds cleanly
- [ ] Manual test: run `toc` interactively, type multi-word input, press Option+Backspace — should delete previous word

🤖 Generated with [Claude Code](https://claude.com/claude-code)