### PR TITLE
Reduce TodoWrite overhead in short sessions

### DIFF
--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -426,7 +426,7 @@ func buildNativeRuntimeNotes(sessionCfg *SessionConfig) string {
 	if !toolEnabled(sessionCfg.RuntimeConfig.EnabledTools, "TodoWrite") {
 		return ""
 	}
-	return todoWriteRuntimeNotes()
+	return todoWriteRuntimeNotes
 }
 
 func toolEnabled(enabled []string, name string) bool {

--- a/internal/runtime/native_test.go
+++ b/internal/runtime/native_test.go
@@ -280,9 +280,9 @@ func TestEnsureSystemPromptInjectsTodoWriteNotes(t *testing.T) {
 	if !strings.Contains(content, "TodoWrite tool") {
 		t.Fatalf("expected TodoWrite runtime notes in system prompt, got %q", content)
 	}
-	for _, needle := range []string{"single-answer requests", "short sessions"} {
+	for _, needle := range []string{todoWriteSkipShortSessions, todoWriteRewriteOnlyOnChange} {
 		if !strings.Contains(content, needle) {
-			t.Fatalf("expected prompt to mention %q in TodoWrite guidance, got %q", needle, content)
+			t.Fatalf("expected prompt to contain TodoWrite guidance %q, got %q", needle, content)
 		}
 	}
 }

--- a/internal/runtime/native_todowrite_guidance.go
+++ b/internal/runtime/native_todowrite_guidance.go
@@ -6,13 +6,12 @@ const (
 	todoWriteUseForMultiStep     = "Use the TodoWrite tool only when the task has multiple meaningful steps and tracking them will help you finish the work."
 	todoWriteSkipShortSessions   = "Skip TodoWrite for single-answer requests, obvious one-step fixes, or short sessions where the overhead is higher than the value."
 	todoWriteRewriteOnlyOnChange = "TodoWrite replaces the entire list on each call, so only rewrite it when the plan or statuses actually changed."
+	todoWriteOneInProgress       = `Prefer only one item with status "in_progress" at a time and mark items complete immediately.`
 )
 
-func todoWriteRuntimeNotes() string {
-	return strings.Join([]string{
-		todoWriteUseForMultiStep,
-		todoWriteSkipShortSessions,
-		todoWriteRewriteOnlyOnChange,
-		`Prefer only one item with status "in_progress" at a time and mark items complete immediately.`,
-	}, "\n")
-}
+var todoWriteRuntimeNotes = strings.Join([]string{
+	todoWriteUseForMultiStep,
+	todoWriteSkipShortSessions,
+	todoWriteRewriteOnlyOnChange,
+	todoWriteOneInProgress,
+}, "\n")

--- a/internal/runtime/native_tool_registry.go
+++ b/internal/runtime/native_tool_registry.go
@@ -248,7 +248,6 @@ Use TodoWrite for multi-step work when progress tracking is genuinely helpful, e
 
 Guidelines:
 - Prefer using TodoWrite only when the task has multiple meaningful steps or coordination points.
-- Do not create or update todos for single-turn answers, obvious one-step fixes, or other short sessions where the list would add overhead.
 - Keep only one item in_progress at a time when possible.
 - Mark items completed immediately after finishing them.
 - If the plan changes, rewrite the full list to match the new reality.


### PR DESCRIPTION
## Summary
- discourage TodoWrite usage for single-answer and one-step native runtime sessions
- align the TodoWrite tool description with the same guidance
- add a runtime prompt test covering the short-session instruction

Closes #180

## Testing
- go test ./internal/runtime/...