### PR TITLE
Tighten behavior runtime semantics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Each behavior has an `on` field that specifies which lifecycle event activates i
 
 Future events (e.g. `session_end`, `idle`) will extend this model to cover more parts of the agent lifecycle.
 
-Each behavior fires at most once per session loop invocation. Behavior names must be unique within an agent.
+Behaviors are evaluated in declaration order. At most one behavior fires per evaluation cycle: the runtime injects the first matching behavior prompt, resets the scoped working set, and continues the loop. One-shot firing state is in-memory for the current `runNativePrompt` invocation; it is not persisted across crash recovery or session resume. Behavior names must be unique within an agent.
 
 ```yaml
 behaviors:
@@ -169,6 +169,7 @@ Behavior conditions are evaluated against a per-behavior-cycle working set (`pen
 
 - `file_written` and `file_edited` use glob matching against file paths recorded by the respective tools.
 - `tool_used` checks whether the named tool appears in the scoped working set. Because the working set deduplicates tool names, `tool_used` means "this tool was invoked at least once since the last behavior evaluation," not "this tool was invoked in the most recent model turn."
+- If multiple behaviors match the same scoped working set, only the first matching behavior in config order fires during that evaluation cycle.
 
 ## Permissions
 

--- a/docs/toc-native-runtime.md
+++ b/docs/toc-native-runtime.md
@@ -191,7 +191,8 @@ Behaviors are evaluated against a scoped working set (`pendingBehaviorChanges`) 
 
 Key details:
 
-- Each behavior fires at most once per session loop invocation, tracked by name in a `firedBehaviors` map.
+- Behaviors are evaluated in declaration order, and only the first matching behavior fires in a given evaluation cycle.
+- Each behavior fires at most once per `runNativePrompt` invocation, tracked by name in an in-memory `firedBehaviors` map. That one-shot state is not persisted across crash recovery or session resume.
 - When a behavior fires, its prompt is injected as a `user` message and the loop continues — the model gets another turn.
 - The scoped working set resets when a behavior fires, so subsequent behaviors evaluate against fresh activity.
 - Conditions use AND semantics: if a behavior specifies both `file_written` and `tool_used`, both must match.

--- a/internal/runtime/behaviors.go
+++ b/internal/runtime/behaviors.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/tiny-oc/toc/internal/agent"
@@ -58,6 +59,8 @@ func resolveBehaviors(cfg []agent.BehaviorConfig) []Behavior {
 	return behaviors
 }
 
+// evaluateBehaviors walks behaviors in declaration order and returns the first
+// matching turn_complete behavior that has not already fired in this prompt run.
 func evaluateBehaviors(changes *WorkingSet, behaviors []Behavior, fired map[string]bool) *Behavior {
 	if changes == nil || len(behaviors) == 0 {
 		return nil
@@ -96,7 +99,7 @@ func (b Behavior) matches(changes *WorkingSet) bool {
 	}
 	if toolName := strings.TrimSpace(b.When.ToolUsed); toolName != "" {
 		matched = true
-		if !containsString(changes.ToolsUsed, toolName) {
+		if !slices.Contains(changes.ToolsUsed, toolName) {
 			return false
 		}
 	}
@@ -105,16 +108,7 @@ func (b Behavior) matches(changes *WorkingSet) bool {
 
 func matchesAnyPath(paths []string, pattern string) bool {
 	for _, path := range paths {
-		if tocsync.MatchesAny(path, []string{pattern}) {
-			return true
-		}
-	}
-	return false
-}
-
-func containsString(values []string, needle string) bool {
-	for _, value := range values {
-		if value == needle {
+		if tocsync.MatchOne(path, pattern) {
 			return true
 		}
 	}

--- a/internal/runtime/behaviors_test.go
+++ b/internal/runtime/behaviors_test.go
@@ -69,3 +69,28 @@ func TestEvaluateBehaviors_SkipsNonTurnComplete(t *testing.T) {
 		t.Fatalf("evaluateBehaviors() = %#v, want nil (wrong lifecycle event)", got)
 	}
 }
+
+func TestEvaluateBehaviors_ReturnsFirstMatchInDeclarationOrder(t *testing.T) {
+	changes := &WorkingSet{
+		FilesWritten: []string{"writing/post.md"},
+	}
+	behaviors := []Behavior{
+		{
+			Name:   "first",
+			On:     "turn_complete",
+			When:   BehaviorCondition{FileWritten: "writing/*.md"},
+			Prompt: "First match.",
+		},
+		{
+			Name:   "second",
+			On:     "turn_complete",
+			When:   BehaviorCondition{FileWritten: "writing/*.md"},
+			Prompt: "Second match.",
+		},
+	}
+
+	got := evaluateBehaviors(changes, behaviors, map[string]bool{})
+	if got == nil || got.Name != "first" {
+		t.Fatalf("evaluateBehaviors() = %#v, want first", got)
+	}
+}

--- a/internal/runtime/native_runner.go
+++ b/internal/runtime/native_runner.go
@@ -595,6 +595,8 @@ func runNativeLoop(client *openRouterClient, state *State, toolSpecs []NativeToo
 	if toolCtx.Config != nil && toolCtx.Config.RuntimeConfig.MaxIterations > 0 {
 		maxIterations = toolCtx.Config.RuntimeConfig.MaxIterations
 	}
+	// One-shot behavior state is intentionally scoped to this runNativePrompt
+	// invocation. It is not persisted across resume/recovery.
 	firedBehaviors := make(map[string]bool)
 	pendingBehaviorChanges := &WorkingSet{}
 	for i := 0; i < maxIterations; i++ {
@@ -721,6 +723,9 @@ func runNativeLoop(client *openRouterClient, state *State, toolSpecs []NativeToo
 			if b := evaluateBehaviors(pendingBehaviorChanges, behaviors, firedBehaviors); b != nil {
 				firedBehaviors[b.Name] = true
 				pendingBehaviorChanges = &WorkingSet{}
+				// Behavior prompts come from trusted agent config, not external
+				// user input. If we later add runtime interpolation here, revisit
+				// this trust boundary before injecting model-visible content.
 				behaviorMsg := Message{Role: "user", Content: b.Prompt}
 				state.Messages = append(state.Messages, behaviorMsg)
 				state.Transcript = append(state.Transcript, behaviorMsg)

--- a/internal/runtime/native_runner_test.go
+++ b/internal/runtime/native_runner_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -596,7 +597,7 @@ func TestRunNativeSession_ExecutesBehaviorOnce(t *testing.T) {
 	if behaviorPrompts != 1 {
 		t.Fatalf("behavior prompt count = %d, want 1", behaviorPrompts)
 	}
-	if !containsString(state.WorkingSet.ToolsUsed, "Write") {
+	if !slices.Contains(state.WorkingSet.ToolsUsed, "Write") {
 		t.Fatalf("expected Write in tools used, got %#v", state.WorkingSet)
 	}
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -18,11 +18,16 @@ type Options struct {
 // (patterns ending in /) and ** for recursive matching.
 func MatchesAny(relPath string, patterns []string) bool {
 	for _, pattern := range patterns {
-		if matchPattern(relPath, pattern) {
+		if MatchOne(relPath, pattern) {
 			return true
 		}
 	}
 	return false
+}
+
+// MatchOne checks whether a relative file path matches a single context pattern.
+func MatchOne(relPath, pattern string) bool {
+	return matchPattern(relPath, pattern)
 }
 
 func matchPattern(relPath, pattern string) bool {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -61,6 +61,26 @@ func TestMatchesAny(t *testing.T) {
 	}
 }
 
+func TestMatchOne(t *testing.T) {
+	tests := []struct {
+		relPath string
+		pattern string
+		want    bool
+	}{
+		{relPath: "docs/api.md", pattern: "docs/", want: true},
+		{relPath: "writing/post.md", pattern: "writing/*.md", want: true},
+		{relPath: "writing/post.txt", pattern: "writing/*.md", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.relPath+"_"+tt.pattern, func(t *testing.T) {
+			if got := MatchOne(tt.relPath, tt.pattern); got != tt.want {
+				t.Fatalf("MatchOne(%q, %q) = %v, want %v", tt.relPath, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
 func joinPatterns(p []string) string {
 	s := ""
 	for i, v := range p {


### PR DESCRIPTION
## Summary
- document declaration-order behavior evaluation and per-run one-shot semantics
- add a trust-boundary note for behavior prompt injection
- replace the ad hoc contains helper and add a single-pattern sync matcher to avoid per-path allocations

## Testing
- go test ./internal/runtime
- go test ./internal/sync
- go test ./internal/agent