### PR TITLE
Fix omitempty on Message.Content causing OpenRouter 500s

### DIFF
--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -14,7 +14,7 @@ const StateVersion = 6
 
 type Message struct {
 	Role         string        `json:"role"`
-	Content      string        `json:"content,omitempty"`
+	Content      string        `json:"content"`
 	Name         string        `json:"name,omitempty"`
 	ToolCallID   string        `json:"tool_call_id,omitempty"`
 	ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`


### PR DESCRIPTION
## Summary
- Remove `omitempty` from the `Content` JSON tag on `Message.Content` in `internal/runtime/state.go`
- Tool messages with empty string content were omitting the `content` field entirely, violating the OpenAI chat completions spec
- OpenRouter returns 500 for these malformed requests

## Test plan
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)