### PR TITLE
Add Liquid LFM 2.5 1.2B Thinking model (free via OpenRouter)

### DIFF
--- a/internal/runtimeinfo/native_models.go
+++ b/internal/runtimeinfo/native_models.go
@@ -135,6 +135,17 @@ var nativeModelProfiles = []NativeModelProfile{
 		MaxOutputTokens:   65536,
 		ReservedBuffer:    8192,
 	},
+	{
+		ID:                "liquid/lfm-2.5-1.2b-thinking:free",
+		Label:             "Liquid LFM 2.5 1.2B Thinking",
+		Description:       "free 1.2B reasoning model from Liquid AI — lightweight for agentic utility tasks",
+		SupportsTools:     true,
+		SupportsStreaming: true,
+		SupportsThinking:  true,
+		ContextWindow:     32768,
+		MaxOutputTokens:   4096,
+		ReservedBuffer:    2048,
+	},
 	// --- Small / utility models (used as small_model for compaction and summarization) ---
 	{
 		ID:                "openai/gpt-4.1-mini",

--- a/internal/runtimeinfo/native_models_test.go
+++ b/internal/runtimeinfo/native_models_test.go
@@ -105,6 +105,25 @@ func TestLookupNativeProfileClaudeHaiku46(t *testing.T) {
 	}
 }
 
+func TestLookupNativeProfileLiquidLFM(t *testing.T) {
+	profile, ok := LookupNativeProfile("liquid/lfm-2.5-1.2b-thinking:free")
+	if !ok {
+		t.Fatal("expected to find liquid/lfm-2.5-1.2b-thinking:free profile")
+	}
+	if profile.Label != "Liquid LFM 2.5 1.2B Thinking" {
+		t.Fatalf("Label = %q, want %q", profile.Label, "Liquid LFM 2.5 1.2B Thinking")
+	}
+	if profile.ContextWindow != 32768 {
+		t.Fatalf("ContextWindow = %d, want 32768", profile.ContextWindow)
+	}
+	if !profile.SupportsTools {
+		t.Fatal("expected SupportsTools = true")
+	}
+	if !profile.SupportsThinking {
+		t.Fatal("expected SupportsThinking = true")
+	}
+}
+
 func TestValidateNativeModel_RejectsUnknownWithoutOverride(t *testing.T) {
 	err := ValidateNativeModel("meta-llama/unknown", false)
 	if err == nil {


### PR DESCRIPTION
## Summary

- Adds `liquid/lfm-2.5-1.2b-thinking:free` to the native runtime model registry
- Free 1.2B parameter thinking model from Liquid AI, routed via OpenRouter
- Supports tools, streaming, and extended thinking (mandatory reasoning with `<think>` delimiters)
- 32k context window — suited as a zero-cost auxiliary model for compaction and summarization

## Usage

As primary model:
```yaml
model: liquid/lfm-2.5-1.2b-thinking:free
```

As small model for utility tasks:
```yaml
model: anthropic/claude-sonnet-4.6
small_model: liquid/lfm-2.5-1.2b-thinking:free
```

## Test plan

- [x] `TestLookupNativeProfileLiquidLFM` — validates profile lookup, label, context window, tools, and thinking support
- [x] All existing runtimeinfo tests pass (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)