### PR TITLE
feat: add Xquik Apify X actors

### DIFF
--- a/registry/skills/analyze-x/SKILL.md
+++ b/registry/skills/analyze-x/SKILL.md
@@ -1,26 +1,68 @@
 ---
 name: analyze-x
-description: Scrape and analyze X/Twitter profiles and tweets using Apify
+description: Scrape and analyze X/Twitter posts, profiles, and audiences using Apify
 metadata:
-  version: "0.1"
+  version: "0.2"
   requires_integration: "apify, twitter"
 ---
 
 # analyze-x
 
-Scrape X/Twitter accounts and tweets to analyze content strategy, engagement patterns, and growth tactics.
+Scrape X/Twitter posts, profiles, and audiences. Analyze content strategy,
+engagement patterns, and growth tactics.
 
-## Scrape a user's recent tweets
+## Scrape a user's recent posts
 
 ```bash
-toc runtime invoke apify run_actor --actorId "apidojo~tweet-scraper" --input '{"startUrls": [{"url": "https://x.com/<username>"}], "maxTweets": 50}'
+toc runtime invoke apify run_actor --actorId "xquik~x-tweet-scraper" --input '{"mode":"profileTweets","twitterHandles":["<username>"],"maxItems":50,"maxItemsPerTarget":50,"outputVariant":"rich","fieldStyle":"camelCase","outputPreset":"nested"}'
 ```
 
 ## Scrape a specific tweet and its replies
 
 ```bash
-toc runtime invoke apify run_actor --actorId "apidojo~tweet-scraper" --input '{"startUrls": [{"url": "https://x.com/<username>/status/<tweet_id>"}]}'
+toc runtime invoke apify run_actor --actorId "xquik~x-tweet-scraper" --input '{"mode":"replies","tweetUrls":["https://x.com/<username>/status/<tweet_id>"],"maxItems":100,"maxItemsPerTarget":100,"includeOriginalTweet":true,"outputVariant":"rich","fieldStyle":"camelCase","outputPreset":"nested"}'
 ```
+
+## Compare follower audiences
+
+```bash
+toc runtime invoke apify run_actor --actorId "xquik~x-follower-scraper" --input '{"twitterHandles":["<account_one>","<account_two>"],"relation":"followers","maxItems":200,"maxItemsPerTarget":100,"outputMode":"full","includeTargetMetadata":true,"dedupeMode":"merge"}'
+```
+
+## Analyze one account's network
+
+```bash
+toc runtime invoke apify run_actor --actorId "xquik~x-follower-scraper" --input '{"twitterHandles":["<username>"],"relations":["followers","following"],"maxItems":200,"maxItemsPerTarget":100,"outputMode":"compact","includeTargetMetadata":true,"dedupeMode":"none"}'
+```
+
+The follower actor supports `followers`, `following`, `verified_followers`,
+`list_members`, `list_followers`, and `community_members`. Its output modes are
+`compact`, `full`, and `raw`. Use `dedupeMode: "none"` to retain target
+provenance, `"first"` to keep the first match, or `"merge"` for overlap
+analysis.
+
+For both actors, `maxItems` caps the whole run. `maxItemsPerTarget` optionally
+caps each target. Nonpositive per-target values are ignored.
+
+Actor listings:
+[Xquik X Tweet Scraper](https://apify.com/xquik/x-tweet-scraper) and
+[Xquik X Follower Scraper](https://apify.com/xquik/x-follower-scraper).
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
+## Existing Tweet Scraper Route
+
+Keep using the existing Apify Actor when that route is already configured:
+
+```bash
+toc runtime invoke apify run_actor --actorId "apidojo~tweet-scraper" --input '{"startUrls":[{"url":"https://x.com/<username>"}],"maxTweets":50}'
+```
+
+```bash
+toc runtime invoke apify run_actor --actorId "apidojo~tweet-scraper" --input '{"startUrls":[{"url":"https://x.com/<username>/status/<tweet_id>"}]}'
+```
+
+Choose an Actor explicitly. Do not replace a working route without user approval.
 
 ## Search recent tweets via API
 

--- a/registry/skills/import-twitter/SKILL.md
+++ b/registry/skills/import-twitter/SKILL.md
@@ -2,7 +2,7 @@
 name: import-twitter
 description: Scrape tweets and threads from X/Twitter using Apify
 metadata:
-  version: "0.1"
+  version: "0.2"
   requires_integration: apify
 ---
 
@@ -10,11 +10,45 @@ metadata:
 
 Scrape tweets and threads from X/Twitter using the Apify integration.
 
-## How to use
+## Choose an actor
+
+Use `xquik~x-tweet-scraper` for bounded searches, timelines, threads, replies,
+quotes, articles, retweeters, or favoriters. Keep
+`apidojo~tweet-scraper` available for existing workflows.
+
+## Scrape a thread
 
 ```bash
-toc runtime invoke apify run_actor --actorId "apidojo~tweet-scraper" --input '{"startUrls": [{"url": "<url>"}]}'
+toc runtime invoke apify run_actor --actorId "xquik~x-tweet-scraper" --input '{"mode":"thread","tweetUrls":["<tweet_url>"],"maxItems":50,"maxItemsPerTarget":50,"outputVariant":"rich","fieldStyle":"camelCase","outputPreset":"nested"}'
 ```
+
+## Search recent posts
+
+```bash
+toc runtime invoke apify run_actor --actorId "xquik~x-tweet-scraper" --input '{"mode":"search","searchTerms":["<query>"],"queryType":"Latest","maxItems":50,"maxItemsPerTarget":50,"includeSearchTerms":true,"outputVariant":"rich","fieldStyle":"camelCase","outputPreset":"nested"}'
+```
+
+## Keep an existing actor workflow
+
+```bash
+toc runtime invoke apify run_actor --actorId "apidojo~tweet-scraper" --input '{"startUrls":[{"url":"<url>"}],"maxItems":50}'
+```
+
+`maxItems` caps the whole Xquik run. `maxItemsPerTarget` optionally caps each
+target in explicit multi-target modes. Nonpositive per-target values are
+ignored.
+
+Supported Xquik modes: `legacy`, `tweet`, `tweets`, `search`, `profileTweets`,
+`profileReplies`, `profileMedia`, `profileLikes`, `listTweets`, `article`,
+`replies`, `quotes`, `thread`, `retweeters`, and `favoriters`.
+
+Output options include `legacy`, `rich`, or `raw`; `camelCase`, `snake_case`,
+or legacy field names; and `nested` or `flat` records.
+
+Actor listing:
+[Xquik X Tweet Scraper](https://apify.com/xquik/x-tweet-scraper).
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ## What to do with the output
 

--- a/registry/skills/index.yaml
+++ b/registry/skills/index.yaml
@@ -27,8 +27,8 @@ skills:
     description: Post tweets and replies to X/Twitter using the Twitter API v2
     tags: [twitter, posting, x]
   - name: analyze-x
-    description: Scrape and analyze X/Twitter profiles and tweets for growth strategy
-    tags: [apify, twitter, analytics, x]
+    description: Scrape and analyze X/Twitter posts, profiles, and audiences for growth strategy
+    tags: [apify, twitter, analytics, audience, followers, x]
   - name: yc-thinking
     description: Core YC and Paul Graham frameworks for startup thinking
     tags: [strategy, yc, frameworks, startup]


### PR DESCRIPTION
## Summary

- add Xquik X Tweet Scraper to the native `import-twitter` workflow
- add Xquik X Tweet Scraper and X Follower Scraper to `analyze-x`
- document bounded search, thread, reply, network, and audience-overlap inputs
- preserve the existing `apidojo~tweet-scraper` workflow
- update skill versions, discovery text, and audience tags

## Safety and compatibility

- every example sets explicit global and per-target result caps
- examples use only current published Actor schema fields
- Actor references point only to their Apify Store listings
- no Actor run was performed

## Validation

- `make lint`
- `make test`
- both changed skills pass the repository-compatible skill validator
- every example payload parses as JSON and matches the published Actor schema keys and enum values
- both Apify Store listing links return successfully
- `git diff --check`

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
